### PR TITLE
fix: route HF parquet path through ByteTrack

### DIFF
--- a/src/crpod/dataset/huggingface.py
+++ b/src/crpod/dataset/huggingface.py
@@ -22,7 +22,8 @@ import numpy as np
 
 from crpod.detection.cards import to_card_play
 from crpod.detection.yolo import YoloDetector
-from crpod.types import Replay
+from crpod.tracking.bytetrack import Tracker
+from crpod.types import CardPlay, Replay
 
 DATASET_ID = "chrisrca/clash-royale-tv-replays"
 
@@ -103,9 +104,20 @@ def _decode_frames(path: Path) -> Iterator[tuple[int, np.ndarray]]:
 
 
 def _parquet_to_replay(path: Path, arena: str, replay_id: str, detector: YoloDetector) -> Replay:
-    detections = detector.infer(_decode_frames(path))
-    plays = [p for p in (to_card_play(d) for d in detections) if p is not None]
-    total_frames = max((p.frame for p in plays), default=0)
+    detections = list(detector.infer(_decode_frames(path)))
+    tracker = Tracker(frame_rate=10)
+    tracks = tracker.update(detections)
+    plays: list[CardPlay] = []
+    for track in tracks:
+        # Drop tracks shorter than 2 frames as detection noise — matches
+        # the video path's `_tracks_to_plays` convention. Anchor at the
+        # first sighting so the CardPlay represents deploy-time placement.
+        if len(track.detections) < 2:
+            continue
+        play = to_card_play(track.detections[0])
+        if play is not None:
+            plays.append(play)
+    total_frames = max((d.frame for d in detections), default=0)
     return Replay(
         replay_id=replay_id,
         arena=arena,

--- a/tests/test_hf_replay.py
+++ b/tests/test_hf_replay.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from crpod.dataset import huggingface as hf
+from crpod.detection.yolo import Detection, YoloDetector
+
+
+def _det(frame: int, cls: str, x: float, y: float) -> Detection:
+    """40x60 box centered at (x, y) — large enough for ByteTrack IoU matching."""
+    return Detection(
+        frame=frame,
+        cls=cls,
+        confidence=0.9,
+        xyxy=(x - 20, y - 30, x + 20, y + 30),
+    )
+
+
+class _StubDetector:
+    """Returns a fixed detection list regardless of input frames."""
+
+    def __init__(self, dets: list[Detection]) -> None:
+        self._dets = dets
+
+    def infer(self, frames: Iterable[tuple[int, object]]) -> list[Detection]:
+        list(frames)  # exhaust in case _decode_frames is real
+        return self._dets
+
+
+@pytest.fixture
+def silenced_decode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace _decode_frames with a no-op so tests don't need a real parquet."""
+    monkeypatch.setattr(hf, "_decode_frames", lambda path: iter([]))
+
+
+def test_parquet_to_replay_collapses_persistent_object(silenced_decode: None) -> None:
+    """A unit detected across many frames should produce ONE CardPlay, not one per frame."""
+    detections = [_det(i, "knight", x=200 + i * 2, y=400) for i in range(15)]
+    detector = _StubDetector(detections)
+
+    replay = hf._parquet_to_replay(
+        Path("ignored.parquet"),
+        arena="arena_15",
+        replay_id="r1",
+        detector=cast(YoloDetector, detector),
+    )
+
+    knight_plays = [p for p in replay.plays if p.card == "knight"]
+    assert len(knight_plays) == 1, f"expected 1 knight CardPlay, got {len(knight_plays)}"
+
+
+def test_parquet_to_replay_drops_singleton_noise(silenced_decode: None) -> None:
+    """A single-frame stray detection shouldn't survive as its own CardPlay.
+
+    Uses the KATACR class name "skeleton" (singular) — which `to_card_play`
+    maps to canonical card "skeletons" (plural) — so under the broken impl
+    the singleton would emit a CardPlay; under the fix the <2-frame track
+    filter drops it.
+    """
+    persistent = [_det(i, "knight", x=200 + i * 2, y=400) for i in range(15)]
+    stray = [_det(7, "skeleton", x=480, y=120)]
+    detector = _StubDetector(persistent + stray)
+
+    replay = hf._parquet_to_replay(
+        Path("ignored.parquet"),
+        arena="arena_15",
+        replay_id="r1",
+        detector=cast(YoloDetector, detector),
+    )
+
+    cards = {p.card for p in replay.plays}
+    assert "skeletons" not in cards, f"singleton stray leaked into plays: {cards}"
+
+
+def test_parquet_to_replay_preserves_katacr_mapping(silenced_decode: None) -> None:
+    """Hyphenated KATACR class names should map to canonical underscored card names."""
+    detections = [_det(i, "the-log", x=300, y=500) for i in range(10)]
+    detector = _StubDetector(detections)
+
+    replay = hf._parquet_to_replay(
+        Path("ignored.parquet"),
+        arena="arena_15",
+        replay_id="r1",
+        detector=cast(YoloDetector, detector),
+    )
+
+    log_plays = [p for p in replay.plays if p.card == "log"]
+    assert len(log_plays) == 1, (
+        f"expected exactly 1 'log' CardPlay (KATACR mapping + tracker collapse), "
+        f"got {len(log_plays)}: {[p.card for p in replay.plays]}"
+    )


### PR DESCRIPTION
## Summary
- `_parquet_to_replay` was emitting one `CardPlay` per detection; a unit visible across N frames produced N events instead of 1, inflating play counts and breaking elixir-trade math
- Now mirrors `analyze_video`: detections → `Tracker` (supervision.ByteTrack) → drop `<2`-frame tracks as noise → `to_card_play(track.detections[0])` so KATACR class-name mapping + non-card filtering are preserved
- Three behavioral tests added in `tests/test_hf_replay.py` (TDD'd, all RED before fix)

## Test plan
- [x] `uv run pytest tests/test_hf_replay.py -v` → 3/3 pass
- [x] `uv run pytest --ignore=tests/test_hud_ocr.py` → 37/37 pass (HUD test fails on env-missing tesseract, unrelated)
- [x] `uv run ruff check .` → clean
- [x] `uv run ruff format --check .` → clean
- [x] `uv run mypy src` → clean

## Out of scope (follow-up)
`pipeline._tracks_to_plays` (the video path) does **not** apply `to_card_play`, so it uses raw YOLO class names and can emit `CardPlay` events for towers / HP bars / non-card classes. Same integration needed there.