### PR TITLE
Finish Clash Royale Post-Game Analyzer: wave 1

### DIFF
--- a/docs/data-quality.md
+++ b/docs/data-quality.md
@@ -1,0 +1,111 @@
+# Data Quality: HF-dataset Side Inference
+
+## Question
+
+`src/crpod/dataset/huggingface.py` decodes raw frame images from
+`chrisrca/clash-royale-tv-replays` and runs YOLO over them to extract
+`CardPlay` events. The dataset does not label which side (friendly /
+enemy) each detection belongs to. We infer side from the y-coordinate
+of the detection center via `_infer_side` in
+`src/crpod/detection/cards.py`:
+
+```python
+def _infer_side(y: int) -> Side:
+    if y < 0:
+        return Side.UNKNOWN
+    return Side.FRIENDLY if y >= RIVER_Y else Side.ENEMY
+```
+
+with `RIVER_Y = ARENA_H // 2 = 480` (frame midpoint, since HF frames
+are 540×960). The EV model trains on this dataset, so a wrong split
+mislabels every training row.
+
+This doc records the wave-1A audit: do the inferred sides match what a
+human sees in the frame?
+
+## Method
+
+`scripts/validate_side_inference.py` was extended with a `--per-arena
+N` flag. We then ran:
+
+```bash
+uv run python scripts/validate_side_inference.py \
+  --weights /Users/max/Clash-Royale-Pod/output/models/crpod_v1_best.pt \
+  --out output/side_validation \
+  --arena arena_15 --per-arena 10
+```
+
+For each replay the script:
+
+1. downloads `arena_15/<replay_id>/frames.parquet` from the HF hub,
+2. picks the frame at index `len(frames) // 2` (mid-match — both
+   players are typically on the board),
+3. runs YOLO at conf=0.25,
+4. classifies every detection's center via `_infer_side` and renders an
+   overlay PNG: green box = FRIENDLY, red = ENEMY, gray = UNKNOWN. The
+   blue horizontal line is `RIVER_Y`; magenta is the frame midpoint
+   (they coincide here).
+
+The eyeball test: (a) does the blue line fall on the visible river, and
+(b) do enemy princess towers cluster above the line, friendly princess
+towers below?
+
+## Results — 10 arena_15 replays
+
+All ten frames are 540×960 (`frame=960x540` in script output =
+`(h, w)`), `RIVER_Y=480`, midpoint=480.
+
+| # | replay_id (prefix) | frame | friendly / enemy / unknown | tower friendly / enemy / total | overlay PNG | eyeball |
+|---|---|---|---|---|---|---|
+| 1 | `00a91415` | 292 | 15 / 11 / 0 | 5 / 5 / 10 | `arena_15_00a91415_frame00292.png` | river line on river; enemy princess towers (red) at y≈210-280, friendly (green) at y≈680-740. Friendly knight at the bottom-half lane correctly green. |
+| 2 | `02c3eb19` | 513 | 13 / 11 / 0 | 6 / 5 / 11 | `arena_15_02c3eb19_frame00513.png` | river line on river; symmetric tower detection; friendly green box around our king tower at y≈800. |
+| 3 | `0364a998` | 384 | 13 / 6 / 0 | 6 / 2 / 8 | `arena_15_0364a998_frame00384.png` | tower count is asymmetric (only 2 enemy towers detected), but every detection is on the *correct* side of the line. Asymmetry is a YOLO recall thing, not a side-classification bug. |
+| 4 | `07eba4b4` | 294 | 11 / 11 / 0 | 7 / 5 / 12 | `arena_15_07eba4b4_frame00294.png` | enemy princess towers + crown HUD all red; friendly side all green; line on river. |
+| 5 | `18ebf665` | 396 | 9 / 9 / 0 | 5 / 6 / 11 | `arena_15_18ebf665_frame00396.png` | "60 SECONDS LEFT" overlay text sits on the river line but does not produce any rogue detection. Tower split balanced. |
+| 6 | `1b27e668` | 317 | 15 / 8 / 0 | 7 / 4 / 11 | `arena_15_1b27e668_frame00317.png` | friendly side has more activity at the snapshot moment (deck swap mid-match). All units correctly green; enemy princess towers correctly red. |
+| 7 | `1dc26cb7` | 312 | 10 / 9 / 0 | 5 / 5 / 10 | `arena_15_1dc26cb7_frame00312.png` | clean balanced split; tower detection symmetric. |
+| 8 | `226fefa9` | 532 | 11 / 10 / 0 | 5 / 4 / 9 | `arena_15_226fefa9_frame00532.png` | friendly units crossing the bridge to attack — the y=480 boundary lands above the bridge crossings, so units on/just past the bridge are correctly labeled by which side of the river they sit on. |
+| 9 | `27125b76` | 429 | 12 / 14 / 0 | 6 / 6 / 12 | `arena_15_27125b76_frame00429.png` | symmetric (6/6 towers), 60-seconds-left overlay; line on river. |
+| 10 | `295a4ed7` | 345 | 11 / 19 / 0 | 5 / 5 / 10 | `arena_15_295a4ed7_frame00345.png` | busiest frame (30 detections); enemy push in progress so naturally more enemy units. All correctly classified. |
+
+### Aggregate (10 replays, mid-match frame each)
+
+- Detections: **228 total** across 10 frames (avg ~23 per frame).
+- Side split: **120 friendly / 108 enemy / 0 unknown** — 53% / 47%, in
+  the ballpark of the 50/50 expected by symmetry of the camera framing.
+- Towers: **57 friendly / 47 enemy / 104 total** — both sides see
+  roughly the expected 5-7 tower detections per frame (1 king + 2
+  princess per side, plus occasional duplicate detections of the
+  6 visible towers and HUD-band crown icons that match `cls.lower()`'s
+  `tower`/`king` keyword).
+- **No detection ever landed on the wrong side** in human eyeball
+  inspection of the 10 overlays.
+
+## Verdict
+
+**The `_infer_side` heuristic is correct on arena_15.** The
+`RIVER_Y=480` constant (set in commit `b99b1bc`) lands on the visible
+river in every inspected frame, and YOLO detections cluster on the
+correct side of that line in 10/10 replays.
+
+**No code change required.** `src/crpod/dataset/huggingface.py`,
+`src/crpod/detection/cards.py:_infer_side`, and
+`src/crpod/constants.py:RIVER_Y` are all left untouched. Wave 2's EV
+re-training can proceed on this dataset with confidence that the side
+labels are accurate.
+
+### Caveats / limits of this audit
+
+- We sampled one mid-match frame per replay. Camera framing in the HF
+  dataset appears static across a single replay, but we did not
+  validate per-frame across the full timeline of any replay. If a
+  future arena introduces dynamic camera offset (e.g. screen
+  shake / zoom), `RIVER_Y` would need re-validation there.
+- Audit was scoped to `arena_15` per the SPEC; the constants comment
+  in `src/crpod/constants.py` already notes a previous five-arena
+  pass (arena_05/15/22/28/31) at the same RIVER_Y=480.
+- Detections at y < 0 (degenerate bbox) get UNKNOWN. We saw zero of
+  these in 228 detections.
+- `BRIDGE_LEFT_X` / `BRIDGE_RIGHT_X` are out of scope for this audit;
+  the pre-existing comment in `constants.py` flags those for separate
+  re-validation.

--- a/docs/yolo-pod-audit.md
+++ b/docs/yolo-pod-audit.md
@@ -1,0 +1,239 @@
+# YOLO Pod-Video Detection Audit
+
+**Model:** `output/models/crpod_v1_best.pt` (YOLOv8s, 201 classes — 155 real
+Clash Royale classes + 44 `pad_*` filler from the KataCR class mapping)
+**Footage:** 3 pod screen-recordings of player **Max**, captured 2026-05-01,
+886 × 1920 portrait at 60 fps, 3–4 min each. Located under
+`data/pod-videos/` (gitignored, large MOVs).
+**Sampling:** 1 frame/s, default `conf=0.25`. ~180–240 frames per match.
+A second pass at `conf=0.05` (essentially the noise floor) was used as a
+sanity check on "the model fails to detect this card" claims — see the
+"Sub-floor verification" section below.
+**Reproducer:** `scripts/audit_pod_videos.py` (commits the script, not the
+output). Raw per-detection CSV + annotated sample frames live in
+`/tmp/yolo_audit_run/`.
+
+> This is a research/documentation chunk, not a code fix. Nothing about
+> the model, constants, or pipeline was changed. Findings here should
+> drive a follow-up issue *if* the EV path on pod videos depends on the
+> classes flagged below.
+
+---
+
+## TL;DR
+
+The detector behaves like a model trained on the HF/KataCR distribution
+when it is shown a different distribution: **HUD and tower geometry
+transfer well, swarm troops transfer okay, and the pod's signature
+big-troop cards (mega-knight, mini-pekka, wizard, giant-skeleton)
+do not appear to fire at all on these recordings** — even when those
+cards are clearly visible in the player's hand and almost certainly
+deployed within each ~3-min match.
+
+Spells (tornado, giant-snowball, fireball) are also effectively
+invisible to the audit at 1 fps because their on-screen footprint lasts
+~0.5 s — but `fireball` produced one detection at conf 0.93, hinting
+the model can see it when sampled near peak.
+
+The aspect ratio gap matters: HF training frames are 540 × 960
+(0.5625), pod recordings are 886 × 1920 (0.461). Ultralytics letterboxes
+during inference, but the resulting in-arena unit sizes do not match
+the training distribution, which is consistent with the pattern we see
+(towers fine, large troops fail).
+
+---
+
+## Pod's deck per match
+
+Reconstructed by visually inspecting the bottom card-tray HUD across
+~5 sampled timestamps per video. Where a card icon was ambiguous I
+flag it with `?`.
+
+### Match 1 (`ScreenRecording_05-01-2026 03-56-58_1.MOV`, 236 s)
+1. **mega-knight** (7) — visible in `Next:` slot at 35 s, 70 s, 117 s, 198 s
+2. **mini-pekka** (4)
+3. **knight** (3) — masked-helmet variant
+4. **giant-snowball** (2)
+5. **tornado** (3)
+6. **bats** (2)? — small skull-with-yellow-goggles icon, 2-cost
+7. **goblin-demolisher** (4)? — bomb-cart icon, 4-cost
+8. one slot I could not nail down across the sampled trays
+
+### Match 2 (`ScreenRecording_05-01-2026 04-01-24_1.MOV`, 181 s)
+Same deck as Match 1 (same player, deck appears unchanged).
+
+### Match 3 (`ScreenRecording_05-01-2026 04-04-50_1.MOV`, 229 s)
+Different archetype — wizard / fireball / heavy beatdown:
+1. **wizard** (5)
+2. **mini-pekka** (4)
+3. **knight** (3)
+4. **fireball** (4)
+5. **giant-skeleton** (6)
+6. **zappies** (4)
+7. an orange "welder/cossack" 4-cost — possibly **mighty-miner** or
+   **goblin-machine** (uncertain)
+8. a 2-cost redhead-with-axe — likely a champion **ability** card slot
+   (cost shown is the ability cost, not the base deploy cost)
+
+---
+
+## Per-card detection findings
+
+The table aggregates across all 3 matches. `n` = total detections at
+`conf>=0.25` across the ~640 sampled frames; `coverage` = fraction of
+frames in which the class appeared at least once; `mean conf` = mean
+score for the class over those detections. "Status" reflects what we
+observed against the on-screen reality, not a benchmark metric.
+
+### Pod-deck cards (the cards that gate EV quality on pod videos)
+
+| Card | Match | n | Coverage | Mean conf | Status | Notes |
+|------|-------|---|----------|-----------|--------|-------|
+| `mega-knight` | 1, 2 | **0** | 0% | — | **fails** | Featured in player's hand frequently. **0 detections even at conf=0.05** in Match 1 — clean negative. Likely the worst single regression on pod footage. |
+| `mini-pekka` | 1, 2, 3 | **0** | 0% | — | **fails** | In every match's deck. At conf=0.05 in Match 1: 1 lone sub-floor detection across 237 frames — effectively zero. |
+| `knight` | 1 | 2 | 0.8% | 0.32 | **flaky** | Both detections hover at the conf floor and at least one looked like a card-tray HUD false-positive (boxed on the bottom card icon, not the field). |
+| `knight` | 2 | 22 | 12% | 0.48 | **flaky** | Better — peaked at 0.94 once but median 0.36; many low-conf hits. |
+| `knight` | 3 | 5 | 2.2% | 0.29 | **flaky** | Sub-floor confidence cluster. |
+| `tornado` | 1, 2 | **0** | 0% | — | **n/a (sampling)** | Spell visual ~0.3–1 s; 1 fps sampling almost guarantees misses. Cannot conclude detection failure from this alone. |
+| `giant-snowball` | 1, 2 | **0** | 0% | — | **n/a (sampling)** | Same — sub-frame spell visual. |
+| `bats` | 1, 2 | 0 | 0% | — | **unknown** | Card identity itself uncertain; skip until reconfirmed. |
+| `goblin-demolisher` | 1, 2 | 0 | 0% | — | **unknown** | Class is **not in the YOLO label set** (model was trained before this card existed in the KataCR mapping). If the pod deploys it, it cannot be detected — this is a class-coverage gap, not a model quality issue. |
+| `wizard` | 3 | **0** | 0% | — | **fails** | Featured card in the deck. **0 detections even at conf=0.05** in Match 3 — clean negative. One stray `wizard` hit at 0.42 in Match 1 is unrelated (opponent had no wizard either; likely a HUD false positive). |
+| `fireball` | 3 | 1 | 0.4% | 0.93 | **catches when sampled** | Single hit at very high confidence. Spell visual is ~0.3 s so absence elsewhere is sampling, not a detector failure. |
+| `giant-skeleton` | 3 | **0** | 0% | — | **fires below floor** | Featured in deck. At conf=0.05 in Match 3: exactly 1 detection at conf 0.19 — the model has *some* weak signal but it never crosses the default 0.25 threshold. Different recommendation than mega-knight: a per-class threshold could partially recover this; a retrain probably can't be avoided either way. |
+| `zappies` (`zappy`) | 1, 2, 3 | 109 / 121 / 73 | 21–34% | 0.54–0.55 | **good** | Most reliable pod-deck card across all matches. Detected even from the sparser HF distribution. |
+| `mighty-miner` | 3 | 5 | 2.2% | 0.44 | **flaky** | Sparse but appears with reasonable confidence when seen. Low coverage may again be sampling, since the unit goes underground for parts of its life. |
+
+### Cross-cutting observations (HUD / towers / opponent cards)
+
+These aren't pod-deck cards, but they're load-bearing for the rest of
+the pipeline (tower HP comes from the bar classes; emote and clock
+classes anchor the HUD masking heuristics).
+
+| Class | Behavior |
+|-------|----------|
+| `king-tower`, `queen-tower`, `cannoneer-tower`, `dagger-duchess-tower` | Detected in ~95–100% of frames, mean conf 0.5–0.85, max ~0.97. **Solid** — tower detection survives the distribution shift cleanly. |
+| `tower-bar`, `bar`, `king-tower-bar` | 80–100% coverage, mean conf 0.6–0.9. **Solid** — feeds the OCR/HP-bar pipeline well. |
+| `text`, `clock`, `emote` | Detected on every frame. Sometimes spurious (HUD card-tray icons get tagged as `clock` or `text` — cosmetic, not load-bearing). |
+| `skeleton`, `goblin` | High counts (Match 1: 465 goblin detections, 95% coverage). Drilled into the persistent goblin cluster in Match 1 (frame 0 onward, box ≈ x∈[336,390], y∈[584,648]) — visually it sits on the **green decorative bush on top of the top king tower**. That single fixture explains most of the goblin count. Worth a follow-up if the EV path consumes raw goblin detections; the same king-tower bush will fire on every pod video taken in this arena. |
+| `hog-rider`, `dark-prince`, `electro-wizard`, `bandit`, `witch`, `executioner`, `golem`, `sparky`, `royal-giant`, `lava-hound` | One- to two-shot detections from opponent decks. Confidences trend low (0.27–0.50) but plausibly real. Useful for the opponent half of EV inference if you treat anything below ~0.4 as noisy. |
+| `tesla-evolution`, `goblin-drill`, `tombstone`, `cannon`, `inferno-tower` | Building detections fire intermittently; only `tesla-evolution` showed up across all 3 matches. Confidences modest. |
+
+### False-positive surface to be aware of
+
+While reviewing annotated frames the recurring artifacts were:
+
+- **Bottom card-tray icons mis-detected as units.** The selected/next
+  card icons get small bounding boxes labeled `knight`, `clock`,
+  `queen-tower`, etc. The bottom ~10% of the frame is HUD; downstream
+  consumers of detections should crop or mask it. The HF training
+  distribution lacks the iPad-style `Next:` chip and the `Max / No
+  Clan` banner, which is why these get hallucinated on.
+- **Top hand chips similarly hallucinated.** The 4 enemy hand cards at
+  the top get labeled (`queen-tower 0.33` on a card icon was visible
+  in Match 1 frame 0).
+- **King-tower decorative bush mis-classified as `goblin`.** Confirmed
+  visually in Match 1: the green shrub painted on top of the top king
+  tower fires a `goblin` detection at conf 0.25–0.50 in nearly every
+  sampled frame. This single static fixture is the dominant source of
+  the inflated goblin count.
+
+---
+
+## Sub-floor verification
+
+To distinguish "model can't see this card" from "model sees it weakly
+but the default `conf=0.25` filter erases it," each video that featured
+a flagged big troop was re-run at `conf=0.05`. Result, restricted to
+each video's deck-relevant cards:
+
+| Card | Video re-run | Detections at conf=0.05 | Verdict |
+|------|--------------|-------------------------|---------|
+| `mega-knight` | Match 1 | 0 | Truly never fires; not a threshold issue. |
+| `mini-pekka` | Match 1 | 1 (sub-floor) | Effectively never fires. |
+| `wizard` | Match 3 | 0 | Truly never fires; not a threshold issue. |
+| `giant-skeleton` | Match 3 | 1 at conf 0.19 | Fires below floor — the model has a faint signal that lowering the per-class threshold could partly recover. |
+| `knight` | Match 1 | 11 (vs 2 at conf=0.25) | Most additions are sub-0.20 noise. The "raise the floor" recommendation below stands. |
+
+Goblin counts in the same low-conf rerun (Match 3) jumped from 55 to
+384 detections, mean conf 0.16, median 0.09 — i.e., the model
+hallucinates faint goblin-shaped signals all over the screen at low
+confidence. Lowering the global threshold is **not** a viable lever
+for the missed big troops; it only adds noise.
+
+---
+
+## Risk to the EV pipeline (and recommendations)
+
+Recommendations only — none implemented in this chunk per `CHUNK.md`.
+
+1. **EV cannot price plays for cards the model never sees.** mega-knight,
+   mini-pekka, wizard, and giant-skeleton are all marquee cards in this
+   pod's two decks and produced **zero** detections in three matches
+   sampled at 1 fps. If `analyze-video` runs on a pod video featuring
+   these decks, the resulting `summary.json` will systematically
+   under-report the player's offensive plays. Recommend gating EV
+   output (or surfacing a warning) when `n_detections / video_duration`
+   for player-side big troops sits at zero — the pipeline shouldn't
+   silently produce confident EV deltas built only on swarm units.
+
+2. **`goblin-demolisher` is a class-coverage gap, not a tuning gap.**
+   The KataCR class map this model was trained against doesn't include
+   `goblin-demolisher` (released after the dataset was last updated).
+   If the pod runs that card, retraining is the only fix — there is no
+   confidence threshold that recovers it. Open as a separate issue
+   tagged "model-class-coverage" rather than touching constants.
+
+3. **HUD region needs masking before detections feed downstream.** The
+   bottom ~10% (card tray) and top ~12% (enemy hand chips + scoreboard)
+   of pod frames produce false positives that look like real units to
+   anything consuming the detection list. Recommend a viewer-aware
+   mask in the video path (analogous to how `dataset/side.py` is split
+   from `dataset/huggingface.py`) — or, cheaper, drop any detection
+   whose centroid falls in `y < 0.13 * H` or `y > 0.87 * H` *before*
+   tracking. This is a one-line guard, not a model change.
+
+4. **For the `knight` class specifically: raise the confidence floor.**
+   On pod footage, `knight` mostly produces sub-0.4 detections, many
+   of which we visually traced to HUD-tray icons rather than the
+   on-field knight. Recommend treating `knight` detections below 0.55
+   as noise for the EV path. (Recommendation only; do **not** change
+   `YoloDetector`'s default `conf` — that would silently drop other
+   classes.) The cleaner home for this is per-class confidence
+   thresholds, which the codebase doesn't have today.
+
+5. **Spells are out of reach at 1 fps and likely 5 fps.** `fireball`
+   produced one 0.93 detection; tornado and snowball produced none. The
+   on-screen visuals are ~0.3–1 s. Either bump sampling fps for the
+   spell-detection sub-step, or accept that the EV path will treat
+   spells as invisible and rely on elixir-bar deltas to infer them.
+
+6. **No critical, reproducible failure to escalate.** The model didn't
+   crash, didn't swap two classes, and didn't degrade catastrophically
+   on the *useful* parts of the frame (towers, swarms, HUD). The
+   findings above are quality regressions and class-coverage gaps that
+   warrant follow-up issues, not an emergency stop on this chunk.
+
+---
+
+## Reproducing the audit
+
+```bash
+# from repo root, with the project venv active (`uv sync` first if needed)
+uv run python scripts/audit_pod_videos.py \
+    --weights output/models/crpod_v1_best.pt \
+    --videos data/pod-videos \
+    --out /tmp/yolo_audit_run \
+    --fps 1.0 \
+    --conf 0.25 \
+    --sample-every 30
+```
+
+Outputs per video:
+- `<stem>__detections.csv` — one row per detection
+- `<stem>__per_class.csv` — aggregated per-class stats
+- `<stem>__frame_<NNNN>.jpg` — annotated samples (~every 30 s of game time)
+
+The script is intentionally small (~140 lines) and does not import
+anything from `src/crpod/` — it talks straight to ultralytics and cv2,
+so it stays usable even if the pipeline package gets refactored.

--- a/docs/yolo-pod-audit.md
+++ b/docs/yolo-pod-audit.md
@@ -58,25 +58,37 @@ flag it with `?`.
 5. **tornado** (3)
 6. **bomber** (2) — pod-owner confirmed
 7. **goblin-drill** (4) — pod-owner confirmed
-8. one slot I could not nail down across the sampled trays
+8. one slot — pod owner suspects an earlier draft was double-counting
+   either tornado or mega-knight as a separate "8th" card; I have 7
+   distinct cards confirmed and the 8th slot remains unidentified
+   from these samples
 
 ### Match 2 (`ScreenRecording_05-01-2026 04-01-24_1.MOV`, 181 s)
 Same deck as Match 1 (same player, deck appears unchanged).
 
 ### Match 3 (`ScreenRecording_05-01-2026 04-04-50_1.MOV`, 229 s)
-Different archetype — wizard / fireball / heavy beatdown:
+Different archetype — wizard / fireball / heavy beatdown. After two
+rounds of pod-owner correction this is **6 of 8** confirmed; the doc
+no longer claims the deck is fully enumerated.
+
 1. **wizard** (5)
 2. **mini-pekka** (4)
-3. masked-helmet 3-cost slot — previously labeled `knight`; pod owner
-   does not run knight, so this is most likely **mega-minion** (the
-   same correction as the Match 1/2 deck) but should be reconfirmed
-4. **fireball** (4)
+3. **zappies** (4) — pod owner correction; an earlier draft listed this
+   slot as `knight`, then `mega-minion`. Both wrong; the 4-elixir
+   helmeted-mechanical icon I was reading as a small humanoid is the
+   zappies card. (This collapses what I had as separate slots #3 and
+   #6 into the same card.)
+4. **fireball** (4) — confirmed
 5. **giant-skeleton** (6)
-6. **zappies** (4)
-7. an orange "welder/cossack" 4-cost — possibly **mighty-miner** or
-   **goblin-machine** (uncertain)
+6. — (was a duplicate ID of zappies; see slot #3)
+7. — (the orange "welder/cossack" icon I previously could not name was
+   the fireball card art; collapses into slot #4)
 8. a 2-cost redhead-with-axe — likely a champion **ability** card slot
    (cost shown is the ability cost, not the base deploy cost)
+
+Net: 6 confirmed cards (wizard, mini-pekka, zappies, fireball,
+giant-skeleton, plus one champion ability), 2 deck slots still
+unidentified from these samples.
 
 ---
 

--- a/docs/yolo-pod-audit.md
+++ b/docs/yolo-pod-audit.md
@@ -52,11 +52,12 @@ flag it with `?`.
 ### Match 1 (`ScreenRecording_05-01-2026 03-56-58_1.MOV`, 236 s)
 1. **mega-knight** (7) — visible in `Next:` slot at 35 s, 70 s, 117 s, 198 s
 2. **mini-pekka** (4)
-3. **knight** (3) — masked-helmet variant
+3. **mega-minion** (3) — pod owner correction; previously mis-identified
+   as `knight` in earlier drafts based on the masked-helmet icon
 4. **giant-snowball** (2)
 5. **tornado** (3)
-6. **bomber** (2) — confirmed by pod owner
-7. **goblin-drill** (4) — confirmed by pod owner
+6. **bomber** (2) — pod-owner confirmed
+7. **goblin-drill** (4) — pod-owner confirmed
 8. one slot I could not nail down across the sampled trays
 
 ### Match 2 (`ScreenRecording_05-01-2026 04-01-24_1.MOV`, 181 s)
@@ -66,7 +67,9 @@ Same deck as Match 1 (same player, deck appears unchanged).
 Different archetype — wizard / fireball / heavy beatdown:
 1. **wizard** (5)
 2. **mini-pekka** (4)
-3. **knight** (3)
+3. masked-helmet 3-cost slot — previously labeled `knight`; pod owner
+   does not run knight, so this is most likely **mega-minion** (the
+   same correction as the Match 1/2 deck) but should be reconfirmed
 4. **fireball** (4)
 5. **giant-skeleton** (6)
 6. **zappies** (4)
@@ -91,9 +94,9 @@ observed against the on-screen reality, not a benchmark metric.
 |------|-------|---|----------|-----------|--------|-------|
 | `mega-knight` | 1, 2 | **0** | 0% | — | **fails** | Featured in player's hand frequently. **0 detections even at conf=0.05** in Match 1 — clean negative. Likely the worst single regression on pod footage. |
 | `mini-pekka` | 1, 2, 3 | **0** | 0% | — | **fails** | In every match's deck. At conf=0.05 in Match 1: 1 lone sub-floor detection across 237 frames — effectively zero. |
-| `knight` | 1 | 2 | 0.8% | 0.32 | **flaky** | Both detections hover at the conf floor and at least one looked like a card-tray HUD false-positive (boxed on the bottom card icon, not the field). |
-| `knight` | 2 | 22 | 12% | 0.48 | **flaky** | Better — peaked at 0.94 once but median 0.36; many low-conf hits. |
-| `knight` | 3 | 5 | 2.2% | 0.29 | **flaky** | Sub-floor confidence cluster. |
+| `mega-minion` | 1 | 4 | 1.7% | 0.49 | **flaky** | Slot #3 of pod's deck. Sparse but max conf only 0.57; the conf=0.05 rerun pulls in 21 detections (8.4% coverage) but median drops to 0.12 — model has a faint signal that mostly misses the floor. |
+| `mega-minion` | 2 | 5 | 2.8% | 0.39 | **flaky** | Same pattern as Match 1; max conf 0.57. |
+| `knight` (opponent / FP) | 1, 2, 3 | 2 / 22 / 5 | 0.8% / 12% / 2.2% | 0.32 / 0.48 / 0.29 | **n/a (not in pod deck)** | Pod owner confirmed they do not run knight in any of these matches. The `knight` detections here are either opponent-side units or HUD false-positives on card-tray icons. Match 2's higher count (max conf 0.94) is most plausibly an opponent's knight deployed in front of a tower. Detection quality data still useful for opponent-card EV inference, but not for pod-deck gating. |
 | `tornado` | 1, 2 | **0** | 0% | — | **n/a (sampling)** | Spell visual ~0.3–1 s; 1 fps sampling almost guarantees misses. Cannot conclude detection failure from this alone. |
 | `giant-snowball` | 1, 2 | **0** | 0% | — | **n/a (sampling)** | Same — sub-frame spell visual. |
 | `bomber` | 1 | 1 | 0.4% | 0.33 | **flaky** | One detection above the default floor; at conf=0.05 the rerun shows 13 detections (5% coverage) but mean conf 0.14 — the model has a faint bomber-shaped signal that almost never crosses 0.25. Confounded by enemy-side bombers in opponent decks (bomber spawns from skeleton-barrel, etc.), so even the few default-conf hits aren't necessarily player-side. |
@@ -197,14 +200,17 @@ Recommendations only — none implemented in this chunk per `CHUNK.md`.
    whose centroid falls in `y < 0.13 * H` or `y > 0.87 * H` *before*
    tracking. This is a one-line guard, not a model change.
 
-4. **For the `knight` class specifically: raise the confidence floor.**
-   On pod footage, `knight` mostly produces sub-0.4 detections, many
-   of which we visually traced to HUD-tray icons rather than the
-   on-field knight. Recommend treating `knight` detections below 0.55
-   as noise for the EV path. (Recommendation only; do **not** change
-   `YoloDetector`'s default `conf` — that would silently drop other
-   classes.) The cleaner home for this is per-class confidence
-   thresholds, which the codebase doesn't have today.
+4. **Per-class confidence thresholds are the missing primitive.**
+   Several classes show distinct, class-specific confidence profiles
+   on pod footage (`mega-minion` and `bomber` produce mostly sub-floor
+   hits; `goblin` produces high-coverage HUD false positives; `knight`
+   detections, all opponent-side here, peak as high as 0.94 but mean
+   sub-0.4). The cleanest fix is a per-class threshold dict consulted
+   in `YoloDetector.infer` *before* it appends to its detection list,
+   rather than the single global `conf=0.25`. **Recommendation only**;
+   do not change the global default — that would silently drop other
+   classes. This belongs in a separate PR with empirical per-class
+   floors derived from a wider audit run.
 
 5. **Spells are out of reach at 1 fps and likely 5 fps.** `fireball`
    produced one 0.93 detection; tornado and snowball produced none. The

--- a/docs/yolo-pod-audit.md
+++ b/docs/yolo-pod-audit.md
@@ -55,13 +55,9 @@ flag it with `?`.
 3. **knight** (3) — masked-helmet variant
 4. **giant-snowball** (2)
 5. **tornado** (3)
-6. **bats** (2)? — small skull-with-yellow-goggles icon, 2-cost (uncertain)
-7. a 4-cost card showing a metal/bomb-cart silhouette (uncertain — not goblin-demolisher per pod owner)
+6. **bomber** (2) — confirmed by pod owner
+7. **goblin-drill** (4) — confirmed by pod owner
 8. one slot I could not nail down across the sampled trays
-
-Two of the eight slots (#6 and #7) are visual guesses; the per-card
-findings table below treats them as "deck ID uncertain" rather than
-making claims about the model's behavior on them.
 
 ### Match 2 (`ScreenRecording_05-01-2026 04-01-24_1.MOV`, 181 s)
 Same deck as Match 1 (same player, deck appears unchanged).
@@ -100,8 +96,10 @@ observed against the on-screen reality, not a benchmark metric.
 | `knight` | 3 | 5 | 2.2% | 0.29 | **flaky** | Sub-floor confidence cluster. |
 | `tornado` | 1, 2 | **0** | 0% | — | **n/a (sampling)** | Spell visual ~0.3–1 s; 1 fps sampling almost guarantees misses. Cannot conclude detection failure from this alone. |
 | `giant-snowball` | 1, 2 | **0** | 0% | — | **n/a (sampling)** | Same — sub-frame spell visual. |
-| `bats` (deck ID uncertain) | 1, 2 | 0 | 0% | — | **unknown** | Slot #6 in Match 1's deck — visual ID is a guess. Skip until reconfirmed. |
-| 4-cost bomb-cart slot (deck ID uncertain) | 1, 2 | — | — | — | **unknown** | Slot #7 in Match 1's deck. Pod owner has confirmed it is **not** goblin-demolisher; until the actual card is named, no claim about detection on it. |
+| `bomber` | 1 | 1 | 0.4% | 0.33 | **flaky** | One detection above the default floor; at conf=0.05 the rerun shows 13 detections (5% coverage) but mean conf 0.14 — the model has a faint bomber-shaped signal that almost never crosses 0.25. Confounded by enemy-side bombers in opponent decks (bomber spawns from skeleton-barrel, etc.), so even the few default-conf hits aren't necessarily player-side. |
+| `bomber` | 2 | 0 | 0% | — | **fails (this match)** | No detections at default conf in Match 2; no low-conf rerun was performed for this video. |
+| `goblin-drill` | 1 | 10 | 4.2% | 0.36 | **good when above ground** | Drill spends most of its life buried; coverage is bound by how often it surfaces, not by the model. Max conf 0.65 — when visible, the model usually catches it. |
+| `goblin-drill` | 2 | 2 | 1.1% | 0.50 | **good when above ground** | Same pattern — sparse but high-quality hits (max 0.61). |
 | `wizard` | 3 | **0** | 0% | — | **fails** | Featured card in the deck. **0 detections even at conf=0.05** in Match 3 — clean negative. One stray `wizard` hit at 0.42 in Match 1 is unrelated (opponent had no wizard either; likely a HUD false positive). |
 | `fireball` | 3 | 1 | 0.4% | 0.93 | **catches when sampled** | Single hit at very high confidence. Spell visual is ~0.3 s so absence elsewhere is sampling, not a detector failure. |
 | `giant-skeleton` | 3 | **0** | 0% | — | **fires below floor** | Featured in deck. At conf=0.05 in Match 3: exactly 1 detection at conf 0.19 — the model has *some* weak signal but it never crosses the default 0.25 threshold. Different recommendation than mega-knight: a per-class threshold could partially recover this; a retrain probably can't be avoided either way. |
@@ -181,14 +179,14 @@ Recommendations only — none implemented in this chunk per `CHUNK.md`.
    for player-side big troops sits at zero — the pipeline shouldn't
    silently produce confident EV deltas built only on swarm units.
 
-2. **Two card slots in the Match 1/2 deck remain visually unidentified.**
-   The pod owner clarified that an earlier draft of this doc
-   mis-identified slot #7 as `goblin-demolisher`; that claim has been
-   removed. Before any EV-pipeline gating logic ships for this deck,
-   the two uncertain slots should be named (1 minute of pod-owner
-   review on a single tray screenshot) so the per-class detection
-   table can be completed. Don't bake "missing class" rules in until
-   we know the actual classes.
+2. **`bomber` needs the same per-class threshold treatment as `knight`.**
+   In the player's deck for Match 1 and 2 the `bomber` class produces
+   detections only at sub-floor confidence (median 0.10 in the
+   conf=0.05 rerun, max 0.33 across 237 frames). Side-attribution is
+   ambiguous because opponents may also run bomber-spawning cards. If
+   the EV path consumes raw `bomber` detections, recommend either a
+   raised per-class floor (~0.5) or a tracker-side filter that drops
+   single-frame `bomber` hits with no corroborating motion.
 
 3. **HUD region needs masking before detections feed downstream.** The
    bottom ~10% (card tray) and top ~12% (enemy hand chips + scoreboard)

--- a/docs/yolo-pod-audit.md
+++ b/docs/yolo-pod-audit.md
@@ -55,9 +55,13 @@ flag it with `?`.
 3. **knight** (3) — masked-helmet variant
 4. **giant-snowball** (2)
 5. **tornado** (3)
-6. **bats** (2)? — small skull-with-yellow-goggles icon, 2-cost
-7. **goblin-demolisher** (4)? — bomb-cart icon, 4-cost
+6. **bats** (2)? — small skull-with-yellow-goggles icon, 2-cost (uncertain)
+7. a 4-cost card showing a metal/bomb-cart silhouette (uncertain — not goblin-demolisher per pod owner)
 8. one slot I could not nail down across the sampled trays
+
+Two of the eight slots (#6 and #7) are visual guesses; the per-card
+findings table below treats them as "deck ID uncertain" rather than
+making claims about the model's behavior on them.
 
 ### Match 2 (`ScreenRecording_05-01-2026 04-01-24_1.MOV`, 181 s)
 Same deck as Match 1 (same player, deck appears unchanged).
@@ -96,8 +100,8 @@ observed against the on-screen reality, not a benchmark metric.
 | `knight` | 3 | 5 | 2.2% | 0.29 | **flaky** | Sub-floor confidence cluster. |
 | `tornado` | 1, 2 | **0** | 0% | — | **n/a (sampling)** | Spell visual ~0.3–1 s; 1 fps sampling almost guarantees misses. Cannot conclude detection failure from this alone. |
 | `giant-snowball` | 1, 2 | **0** | 0% | — | **n/a (sampling)** | Same — sub-frame spell visual. |
-| `bats` | 1, 2 | 0 | 0% | — | **unknown** | Card identity itself uncertain; skip until reconfirmed. |
-| `goblin-demolisher` | 1, 2 | 0 | 0% | — | **unknown** | Class is **not in the YOLO label set** (model was trained before this card existed in the KataCR mapping). If the pod deploys it, it cannot be detected — this is a class-coverage gap, not a model quality issue. |
+| `bats` (deck ID uncertain) | 1, 2 | 0 | 0% | — | **unknown** | Slot #6 in Match 1's deck — visual ID is a guess. Skip until reconfirmed. |
+| 4-cost bomb-cart slot (deck ID uncertain) | 1, 2 | — | — | — | **unknown** | Slot #7 in Match 1's deck. Pod owner has confirmed it is **not** goblin-demolisher; until the actual card is named, no claim about detection on it. |
 | `wizard` | 3 | **0** | 0% | — | **fails** | Featured card in the deck. **0 detections even at conf=0.05** in Match 3 — clean negative. One stray `wizard` hit at 0.42 in Match 1 is unrelated (opponent had no wizard either; likely a HUD false positive). |
 | `fireball` | 3 | 1 | 0.4% | 0.93 | **catches when sampled** | Single hit at very high confidence. Spell visual is ~0.3 s so absence elsewhere is sampling, not a detector failure. |
 | `giant-skeleton` | 3 | **0** | 0% | — | **fires below floor** | Featured in deck. At conf=0.05 in Match 3: exactly 1 detection at conf 0.19 — the model has *some* weak signal but it never crosses the default 0.25 threshold. Different recommendation than mega-knight: a per-class threshold could partially recover this; a retrain probably can't be avoided either way. |
@@ -177,12 +181,14 @@ Recommendations only — none implemented in this chunk per `CHUNK.md`.
    for player-side big troops sits at zero — the pipeline shouldn't
    silently produce confident EV deltas built only on swarm units.
 
-2. **`goblin-demolisher` is a class-coverage gap, not a tuning gap.**
-   The KataCR class map this model was trained against doesn't include
-   `goblin-demolisher` (released after the dataset was last updated).
-   If the pod runs that card, retraining is the only fix — there is no
-   confidence threshold that recovers it. Open as a separate issue
-   tagged "model-class-coverage" rather than touching constants.
+2. **Two card slots in the Match 1/2 deck remain visually unidentified.**
+   The pod owner clarified that an earlier draft of this doc
+   mis-identified slot #7 as `goblin-demolisher`; that claim has been
+   removed. Before any EV-pipeline gating logic ships for this deck,
+   the two uncertain slots should be named (1 minute of pod-owner
+   review on a single tray screenshot) so the per-class detection
+   table can be completed. Don't bake "missing class" rules in until
+   we know the actual classes.
 
 3. **HUD region needs masking before detections feed downstream.** The
    bottom ~10% (card tray) and top ~12% (enemy hand chips + scoreboard)

--- a/scripts/audit_pod_videos.py
+++ b/scripts/audit_pod_videos.py
@@ -1,0 +1,159 @@
+"""Audit `output/models/crpod_v1_best.pt` on the pod's own match videos.
+
+The model was trained on HF + KataCR data (540x960 frames). The pod plays the
+real game on real devices, which produces different aspect ratios, skins,
+emote overlays, and screen elements. This script does not retrain anything —
+it just runs the model over a few sampled frames per video and prints a
+per-class detection summary so we can see which cards survive the
+distribution shift and which silently fail.
+
+Usage:
+    uv run python scripts/audit_pod_videos.py \\
+        --weights output/models/crpod_v1_best.pt \\
+        --videos data/pod-videos \\
+        --out /tmp/yolo_audit_out \\
+        --fps 1.0 \\
+        --conf 0.25
+
+Outputs:
+- `<out>/<video_stem>__detections.csv` — one row per detection
+- `<out>/<video_stem>__per_class.csv` — aggregate stats per class
+- `<out>/<video_stem>__frame_<N>.jpg` — annotated samples (every Kth frame)
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from collections import defaultdict
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+# `pad_*` classes are KataCR mapping filler — they cannot legitimately
+# appear on a real Clash Royale screen, so they are surfaced separately
+# as a sanity check rather than mixed into the per-card report.
+PAD_PREFIX = "pad_"
+
+
+def _iter_frames(path: Path, target_fps: float) -> list[tuple[int, np.ndarray]]:
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        raise FileNotFoundError(f"cannot open {path}")
+    src_fps = cap.get(cv2.CAP_PROP_FPS) or target_fps
+    step = max(1, round(src_fps / target_fps))
+    out: list[tuple[int, np.ndarray]] = []
+    idx = 0
+    out_idx = 0
+    while True:
+        ok, frame = cap.read()
+        if not ok:
+            break
+        if idx % step == 0:
+            out.append((out_idx, frame))
+            out_idx += 1
+        idx += 1
+    cap.release()
+    return out
+
+
+def _draw(frame: np.ndarray, boxes: list[tuple[str, float, tuple[float, float, float, float]]]) -> np.ndarray:
+    img = frame.copy()
+    for cls, conf, (x1, y1, x2, y2) in boxes:
+        color = (0, 255, 0) if conf >= 0.5 else (0, 165, 255)
+        cv2.rectangle(img, (int(x1), int(y1)), (int(x2), int(y2)), color, 2)
+        label = f"{cls} {conf:.2f}"
+        cv2.putText(img, label, (int(x1), max(int(y1) - 5, 12)),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1, cv2.LINE_AA)
+    return img
+
+
+def audit(weights: Path, video: Path, out_dir: Path, target_fps: float, conf: float, sample_every: int) -> None:
+    from ultralytics import YOLO
+
+    model = YOLO(str(weights))
+    names = model.names
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    stem = video.stem.replace(" ", "_")
+    det_csv = out_dir / f"{stem}__detections.csv"
+    cls_csv = out_dir / f"{stem}__per_class.csv"
+
+    frames = _iter_frames(video, target_fps)
+    n_frames = len(frames)
+    print(f"[{video.name}] sampled {n_frames} frames at ~{target_fps} fps")
+
+    per_class_confs: dict[str, list[float]] = defaultdict(list)
+    per_class_frames: dict[str, set[int]] = defaultdict(set)
+
+    with det_csv.open("w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(["frame", "cls", "confidence", "x1", "y1", "x2", "y2"])
+
+        for i, (fidx, frame) in enumerate(frames):
+            results = model.predict(frame, conf=conf, verbose=False)
+            boxes_for_draw: list[tuple[str, float, tuple[float, float, float, float]]] = []
+            for r in results:
+                for box in r.boxes:
+                    cls_id = int(box.cls.item())
+                    cls = str(names[cls_id])
+                    c = float(box.conf.item())
+                    x1, y1, x2, y2 = (float(v) for v in box.xyxy[0].tolist())
+                    w.writerow([fidx, cls, f"{c:.4f}", f"{x1:.1f}", f"{y1:.1f}", f"{x2:.1f}", f"{y2:.1f}"])
+                    per_class_confs[cls].append(c)
+                    per_class_frames[cls].add(fidx)
+                    boxes_for_draw.append((cls, c, (x1, y1, x2, y2)))
+
+            if i % sample_every == 0:
+                annotated = _draw(frame, boxes_for_draw)
+                cv2.imwrite(str(out_dir / f"{stem}__frame_{fidx:04d}.jpg"), annotated)
+
+    with cls_csv.open("w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(["cls", "n_detections", "n_frames", "frame_coverage_pct", "mean_conf", "median_conf", "max_conf", "is_pad"])
+        rows = []
+        for cls, confs in per_class_confs.items():
+            n = len(confs)
+            nf = len(per_class_frames[cls])
+            cov = 100.0 * nf / max(n_frames, 1)
+            mean_c = float(np.mean(confs))
+            median_c = float(np.median(confs))
+            max_c = float(np.max(confs))
+            is_pad = cls.startswith(PAD_PREFIX)
+            rows.append((cls, n, nf, cov, mean_c, median_c, max_c, is_pad))
+        rows.sort(key=lambda r: (-r[1]))
+        for r in rows:
+            cls, n, nf, cov, mn, md, mx, ispad = r
+            w.writerow([cls, n, nf, f"{cov:.1f}", f"{mn:.3f}", f"{md:.3f}", f"{mx:.3f}", "1" if ispad else "0"])
+
+    print(f"[{video.name}] wrote {det_csv.name}, {cls_csv.name}")
+    print(f"[{video.name}] top 15 classes by detection count:")
+    for r in rows[:15]:
+        cls, n, nf, cov, mn, md, mx, ispad = r
+        tag = "  (PAD)" if ispad else ""
+        print(f"  {cls:30s}  n={n:5d}  frames={nf:4d} ({cov:5.1f}%)  mean={mn:.2f}  med={md:.2f}  max={mx:.2f}{tag}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--weights", type=Path, required=True)
+    ap.add_argument("--videos", type=Path, required=True, help="directory of pod videos")
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--fps", type=float, default=1.0)
+    ap.add_argument("--conf", type=float, default=0.25)
+    ap.add_argument("--sample-every", type=int, default=20,
+                    help="save an annotated frame every Nth sampled frame (1 fps default => every 20s)")
+    ap.add_argument("--glob", default="*.MOV")
+    args = ap.parse_args()
+
+    vids = sorted(args.videos.glob(args.glob))
+    if not vids:
+        raise SystemExit(f"no videos matched {args.videos}/{args.glob}")
+    args.out.mkdir(parents=True, exist_ok=True)
+    for v in vids:
+        audit(args.weights, v, args.out, args.fps, args.conf, args.sample_every)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_pod_videos.py
+++ b/scripts/audit_pod_videos.py
@@ -58,7 +58,10 @@ def _iter_frames(path: Path, target_fps: float) -> list[tuple[int, np.ndarray]]:
     return out
 
 
-def _draw(frame: np.ndarray, boxes: list[tuple[str, float, tuple[float, float, float, float]]]) -> np.ndarray:
+def _draw(
+    frame: np.ndarray,
+    boxes: list[tuple[str, float, tuple[float, float, float, float]]],
+) -> np.ndarray:
     img = frame.copy()
     for cls, conf, (x1, y1, x2, y2) in boxes:
         color = (0, 255, 0) if conf >= 0.5 else (0, 165, 255)
@@ -69,7 +72,14 @@ def _draw(frame: np.ndarray, boxes: list[tuple[str, float, tuple[float, float, f
     return img
 
 
-def audit(weights: Path, video: Path, out_dir: Path, target_fps: float, conf: float, sample_every: int) -> None:
+def audit(
+    weights: Path,
+    video: Path,
+    out_dir: Path,
+    target_fps: float,
+    conf: float,
+    sample_every: int,
+) -> None:
     from ultralytics import YOLO
 
     model = YOLO(str(weights))
@@ -100,7 +110,10 @@ def audit(weights: Path, video: Path, out_dir: Path, target_fps: float, conf: fl
                     cls = str(names[cls_id])
                     c = float(box.conf.item())
                     x1, y1, x2, y2 = (float(v) for v in box.xyxy[0].tolist())
-                    w.writerow([fidx, cls, f"{c:.4f}", f"{x1:.1f}", f"{y1:.1f}", f"{x2:.1f}", f"{y2:.1f}"])
+                    w.writerow([
+                        fidx, cls, f"{c:.4f}",
+                        f"{x1:.1f}", f"{y1:.1f}", f"{x2:.1f}", f"{y2:.1f}",
+                    ])
                     per_class_confs[cls].append(c)
                     per_class_frames[cls].add(fidx)
                     boxes_for_draw.append((cls, c, (x1, y1, x2, y2)))
@@ -111,7 +124,10 @@ def audit(weights: Path, video: Path, out_dir: Path, target_fps: float, conf: fl
 
     with cls_csv.open("w", newline="") as fh:
         w = csv.writer(fh)
-        w.writerow(["cls", "n_detections", "n_frames", "frame_coverage_pct", "mean_conf", "median_conf", "max_conf", "is_pad"])
+        w.writerow([
+            "cls", "n_detections", "n_frames", "frame_coverage_pct",
+            "mean_conf", "median_conf", "max_conf", "is_pad",
+        ])
         rows = []
         for cls, confs in per_class_confs.items():
             n = len(confs)
@@ -125,14 +141,21 @@ def audit(weights: Path, video: Path, out_dir: Path, target_fps: float, conf: fl
         rows.sort(key=lambda r: (-r[1]))
         for r in rows:
             cls, n, nf, cov, mn, md, mx, ispad = r
-            w.writerow([cls, n, nf, f"{cov:.1f}", f"{mn:.3f}", f"{md:.3f}", f"{mx:.3f}", "1" if ispad else "0"])
+            w.writerow([
+                cls, n, nf,
+                f"{cov:.1f}", f"{mn:.3f}", f"{md:.3f}", f"{mx:.3f}",
+                "1" if ispad else "0",
+            ])
 
     print(f"[{video.name}] wrote {det_csv.name}, {cls_csv.name}")
     print(f"[{video.name}] top 15 classes by detection count:")
     for r in rows[:15]:
         cls, n, nf, cov, mn, md, mx, ispad = r
         tag = "  (PAD)" if ispad else ""
-        print(f"  {cls:30s}  n={n:5d}  frames={nf:4d} ({cov:5.1f}%)  mean={mn:.2f}  med={md:.2f}  max={mx:.2f}{tag}")
+        print(
+            f"  {cls:30s}  n={n:5d}  frames={nf:4d} ({cov:5.1f}%)  "
+            f"mean={mn:.2f}  med={md:.2f}  max={mx:.2f}{tag}"
+        )
 
 
 def main() -> None:
@@ -142,8 +165,10 @@ def main() -> None:
     ap.add_argument("--out", type=Path, required=True)
     ap.add_argument("--fps", type=float, default=1.0)
     ap.add_argument("--conf", type=float, default=0.25)
-    ap.add_argument("--sample-every", type=int, default=20,
-                    help="save an annotated frame every Nth sampled frame (1 fps default => every 20s)")
+    ap.add_argument(
+        "--sample-every", type=int, default=20,
+        help="save an annotated frame every Nth sampled frame (1 fps default => every 20s)",
+    )
     ap.add_argument("--glob", default="*.MOV")
     args = ap.parse_args()
 

--- a/scripts/audit_pod_videos.py
+++ b/scripts/audit_pod_videos.py
@@ -67,8 +67,16 @@ def _draw(
         color = (0, 255, 0) if conf >= 0.5 else (0, 165, 255)
         cv2.rectangle(img, (int(x1), int(y1)), (int(x2), int(y2)), color, 2)
         label = f"{cls} {conf:.2f}"
-        cv2.putText(img, label, (int(x1), max(int(y1) - 5, 12)),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1, cv2.LINE_AA)
+        cv2.putText(
+            img,
+            label,
+            (int(x1), max(int(y1) - 5, 12)),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.5,
+            color,
+            1,
+            cv2.LINE_AA,
+        )
     return img
 
 
@@ -110,10 +118,17 @@ def audit(
                     cls = str(names[cls_id])
                     c = float(box.conf.item())
                     x1, y1, x2, y2 = (float(v) for v in box.xyxy[0].tolist())
-                    w.writerow([
-                        fidx, cls, f"{c:.4f}",
-                        f"{x1:.1f}", f"{y1:.1f}", f"{x2:.1f}", f"{y2:.1f}",
-                    ])
+                    w.writerow(
+                        [
+                            fidx,
+                            cls,
+                            f"{c:.4f}",
+                            f"{x1:.1f}",
+                            f"{y1:.1f}",
+                            f"{x2:.1f}",
+                            f"{y2:.1f}",
+                        ]
+                    )
                     per_class_confs[cls].append(c)
                     per_class_frames[cls].add(fidx)
                     boxes_for_draw.append((cls, c, (x1, y1, x2, y2)))
@@ -124,10 +139,18 @@ def audit(
 
     with cls_csv.open("w", newline="") as fh:
         w = csv.writer(fh)
-        w.writerow([
-            "cls", "n_detections", "n_frames", "frame_coverage_pct",
-            "mean_conf", "median_conf", "max_conf", "is_pad",
-        ])
+        w.writerow(
+            [
+                "cls",
+                "n_detections",
+                "n_frames",
+                "frame_coverage_pct",
+                "mean_conf",
+                "median_conf",
+                "max_conf",
+                "is_pad",
+            ]
+        )
         rows = []
         for cls, confs in per_class_confs.items():
             n = len(confs)
@@ -138,14 +161,21 @@ def audit(
             max_c = float(np.max(confs))
             is_pad = cls.startswith(PAD_PREFIX)
             rows.append((cls, n, nf, cov, mean_c, median_c, max_c, is_pad))
-        rows.sort(key=lambda r: (-r[1]))
+        rows.sort(key=lambda r: -r[1])
         for r in rows:
             cls, n, nf, cov, mn, md, mx, ispad = r
-            w.writerow([
-                cls, n, nf,
-                f"{cov:.1f}", f"{mn:.3f}", f"{md:.3f}", f"{mx:.3f}",
-                "1" if ispad else "0",
-            ])
+            w.writerow(
+                [
+                    cls,
+                    n,
+                    nf,
+                    f"{cov:.1f}",
+                    f"{mn:.3f}",
+                    f"{md:.3f}",
+                    f"{mx:.3f}",
+                    "1" if ispad else "0",
+                ]
+            )
 
     print(f"[{video.name}] wrote {det_csv.name}, {cls_csv.name}")
     print(f"[{video.name}] top 15 classes by detection count:")
@@ -166,7 +196,9 @@ def main() -> None:
     ap.add_argument("--fps", type=float, default=1.0)
     ap.add_argument("--conf", type=float, default=0.25)
     ap.add_argument(
-        "--sample-every", type=int, default=20,
+        "--sample-every",
+        type=int,
+        default=20,
         help="save an annotated frame every Nth sampled frame (1 fps default => every 20s)",
     )
     ap.add_argument("--glob", default="*.MOV")

--- a/scripts/validate_side_inference.py
+++ b/scripts/validate_side_inference.py
@@ -223,9 +223,7 @@ def main() -> None:
         replays = [(a, r) for a, r in args.replay]
     else:
         arenas = args.arena or [a for a, _ in DEFAULT_REPLAYS]
-        replays = [
-            (a, r) for a in arenas for r in _list_first_replays(a, n=args.per_arena)
-        ]
+        replays = [(a, r) for a in arenas for r in _list_first_replays(a, n=args.per_arena)]
 
     detector = YoloDetector(args.weights, conf=args.conf)
     print(f"validating side inference on {len(replays)} replays")

--- a/scripts/validate_side_inference.py
+++ b/scripts/validate_side_inference.py
@@ -58,12 +58,13 @@ def _is_tower(cls: str) -> bool:
     return any(k in cls.lower() for k in TOWER_KEYWORDS)
 
 
-def _list_first_replay(arena: str, token: str | None = None) -> str:
-    """Return the first replay_id available for `arena`."""
+def _list_first_replays(arena: str, n: int = 1, token: str | None = None) -> list[str]:
+    """Return up to `n` replay_ids available for `arena`, in dataset order."""
     from huggingface_hub import HfApi
 
     api = HfApi(token=token)
     files = api.list_repo_files(DATASET_ID, repo_type="dataset")
+    out: list[str] = []
     for f in files:
         if not f.endswith("/frames.parquet"):
             continue
@@ -72,8 +73,12 @@ def _list_first_replay(arena: str, token: str | None = None) -> str:
             continue
         a, r = parts[-3], parts[-2]
         if a == arena:
-            return r
-    raise SystemExit(f"no replays found for {arena}")
+            out.append(r)
+            if len(out) >= n:
+                break
+    if not out:
+        raise SystemExit(f"no replays found for {arena}")
+    return out
 
 
 def _pick_mid_frame(parquet_path: Path) -> tuple[int, np.ndarray]:
@@ -157,13 +162,29 @@ def _draw(img: np.ndarray, dets: list[Detection]) -> np.ndarray:
     return out
 
 
+def _side_counts(dets: list[Detection]) -> tuple[int, int, int]:
+    """Return (friendly, enemy, unknown) counts across all detections."""
+    f = e = u = 0
+    for d in dets:
+        side = _infer_side(int(d.center[1]))
+        if side is Side.FRIENDLY:
+            f += 1
+        elif side is Side.ENEMY:
+            e += 1
+        else:
+            u += 1
+    return f, e, u
+
+
 def _verdict_line(dets: list[Detection], img_shape: tuple[int, int]) -> str:
     h, w = img_shape
     towers = [d for d in dets if _is_tower(d.cls)]
     enemy_towers = sum(1 for d in towers if _infer_side(int(d.center[1])) is Side.ENEMY)
     friendly_towers = sum(1 for d in towers if _infer_side(int(d.center[1])) is Side.FRIENDLY)
+    fr, en, un = _side_counts(dets)
     return (
         f"frame={h}x{w}  RIVER_Y={RIVER_Y}  midpoint={h // 2}  "
+        f"all dets: {fr} friendly / {en} enemy / {un} unknown ({len(dets)} total)  "
         f"towers: {friendly_towers} friendly / {enemy_towers} enemy / {len(towers)} total"
     )
 
@@ -177,6 +198,12 @@ def main() -> None:
         "--arena",
         action="append",
         help="repeat to override default arena set (uses first replay in each)",
+    )
+    p.add_argument(
+        "--per-arena",
+        type=int,
+        default=1,
+        help="how many replays per --arena to validate (default: 1)",
     )
     p.add_argument(
         "--replay",
@@ -196,7 +223,9 @@ def main() -> None:
         replays = [(a, r) for a, r in args.replay]
     else:
         arenas = args.arena or [a for a, _ in DEFAULT_REPLAYS]
-        replays = [(a, _list_first_replay(a)) for a in arenas]
+        replays = [
+            (a, r) for a in arenas for r in _list_first_replays(a, n=args.per_arena)
+        ]
 
     detector = YoloDetector(args.weights, conf=args.conf)
     print(f"validating side inference on {len(replays)} replays")

--- a/src/crpod/constants.py
+++ b/src/crpod/constants.py
@@ -125,6 +125,19 @@ CARD_COSTS: dict[str, int] = {
     "little_prince": 3,
     "goblin_machine": 5,
     "goblinstein": 5,
+    "boss_bandit": 6,
+    # `terry` was a temporary Super Champion event card (active 2023-01-05
+    # through 2023-09-05); kept here because the YOLO mapping covers it
+    # and historical replays may still surface it.
+    "terry": 4,
+    # Recently-released non-champion troops previously parked in
+    # _KNOWN_UNCONFIRMED_COSTS — both confirmed against in-game card view.
+    "rune_giant": 4,
+    # Spirit Empress has a dual-form deploy: 3 elixir as the ground troop,
+    # 6 elixir as the dragon (auto-selected based on available elixir).
+    # CARD_COSTS stores the headline 6-elixir value; downstream code that
+    # needs the alternate must special-case it.
+    "spirit_empress": 6,
     # Buildings
     "cannon": 3,
     "tesla": 4,
@@ -159,6 +172,12 @@ CARD_COSTS: dict[str, int] = {
     "goblin_barrel": 3,
     "goblin_curse": 3,
     "void": 3,
+    # Mirror is variable-cost: effective deploy cost is
+    # `last_card_played.cost + 1`, clamped to [2, 10]. The 1 here matches
+    # Supercell's `spells_other.csv:Mirror.ManaCost` (the surcharge).
+    # Callers that need the effective per-play cost must reconstruct it
+    # from the previous CardPlay; this constant is only a fallback.
+    "mirror": 1,
 }
 
 

--- a/src/crpod/detection/cards.py
+++ b/src/crpod/detection/cards.py
@@ -23,24 +23,11 @@ from crpod.types import CardPlay, Side
 _log = logging.getLogger(__name__)
 _warned: set[str] = set()
 
-# Cards whose elixir cost Supercell hasn't published yet (or has a special
-# variable cost, in the case of mirror). They may appear as values in
-# KATACR_TO_CARD without a matching CARD_COSTS row; the validity test
-# allows this. ``card_cost()`` falls back to ``default=3`` for them.
-_KNOWN_UNCONFIRMED_COSTS: Final[frozenset[str]] = frozenset(
-    {
-        # Champions whose costs aren't published yet
-        "boss_bandit",
-        "rune_giant",
-        "spirit_empress",
-        "terry",
-        # Recently-released cards needing source verification
-        "goblin_brawler",
-        "royal_guardian",
-        # Variable-cost card (mirror = cost of last card played)
-        "mirror",
-    }
-)
+# Historically held card names whose elixir cost Supercell hadn't yet
+# published. All entries have since been resolved (see CARD_COSTS) or
+# reclassified as spawned subunits in KATACR_NON_CARD. Kept as a named
+# (empty) constant for the validity test in tests/test_cards.py.
+_KNOWN_UNCONFIRMED_COSTS: Final[frozenset[str]] = frozenset()
 
 # KataCR class name -> canonical CARD_COSTS key. Generated against
 # ``katacr_classes.txt`` (derived from upstream KataCR's public
@@ -90,10 +77,7 @@ KATACR_TO_CARD: dict[str, str] = {
     "tesla-evolution": "tesla",
     "valkyrie-evolution": "valkyrie",
     "wall-breaker-evolution": "wall_breakers",
-    # Cards needing cost source verification (see _KNOWN_UNCONFIRMED_COSTS)
     "mirror": "mirror",
-    "goblin-brawler": "goblin_brawler",
-    "royal-guardian": "royal_guardian",
     # Standard cards (kebab-case in KataCR -> underscore in CARD_COSTS)
     "archer-queen": "archer_queen",
     "arrows": "arrows",
@@ -202,8 +186,12 @@ KATACR_NON_CARD: frozenset[str] = frozenset(
         "emote",
         "evolution-symbol",
         "goblin-ball",
+        # Spawned subunits (cage/ability outputs, not card plays) —
+        # same pattern as golemite/lava-pup/hog below.
+        "goblin-brawler",
         "golemite",
         "hog",
+        "royal-guardian",
         "ice-spirit-evolution-symbol",
         "king-tower",
         "king-tower-bar",

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -85,21 +85,53 @@ class TestToCardPlay:
 
 
 class TestMappingValidity:
-    def test_every_alias_target_has_known_cost_or_is_unconfirmed_champion(self):
-        """Each value in KATACR_TO_CARD must be a key in CARD_COSTS, OR one
-        of the 4 champions whose costs Supercell hasn't published yet."""
-        bad = []
-        for katacr_name, canonical in KATACR_TO_CARD.items():
-            if canonical in CARD_COSTS:
-                continue
-            if canonical in _KNOWN_UNCONFIRMED_COSTS:
-                continue
-            bad.append(f"{katacr_name!r} -> {canonical!r}")
+    def test_every_alias_target_has_known_cost(self):
+        """Every canonical target in KATACR_TO_CARD must have a row in
+        CARD_COSTS. The historical 'unconfirmed' escape hatch is gone."""
+        bad = [
+            f"{katacr_name!r} -> {canonical!r}"
+            for katacr_name, canonical in KATACR_TO_CARD.items()
+            if canonical not in CARD_COSTS
+        ]
         assert not bad, "KATACR_TO_CARD has aliases pointing nowhere:\n  " + "\n  ".join(bad)
+
+    def test_known_unconfirmed_costs_is_empty(self):
+        """Sentinel: the set must stay empty. If a new card appears whose
+        cost is genuinely unknown, add it to CARD_COSTS with a sourced
+        value rather than re-populating this set."""
+        assert _KNOWN_UNCONFIRMED_COSTS == frozenset()
 
     def test_no_overlap_between_card_and_non_card(self):
         overlap = set(KATACR_TO_CARD.keys()) & KATACR_NON_CARD
         assert not overlap, f"classes in both card and non-card sets: {overlap}"
+
+    @pytest.mark.parametrize(
+        ("card", "expected_cost"),
+        [
+            ("boss_bandit", 6),
+            ("rune_giant", 4),
+            ("spirit_empress", 6),
+            ("terry", 4),
+            ("mirror", 1),
+        ],
+    )
+    def test_wave_1b_costs_are_present(self, card, expected_cost):
+        """Costs sourced in the Wave 1B commit (see commit message for
+        per-card citations). Spirit Empress stores the headline 6-elixir
+        cost; Mirror stores the +1 surcharge from spells_other.csv."""
+        assert card in CARD_COSTS, f"{card} missing from CARD_COSTS"
+        assert CARD_COSTS[card] == expected_cost, (
+            f"{card} cost mismatch: CARD_COSTS={CARD_COSTS[card]} expected={expected_cost}"
+        )
+
+    @pytest.mark.parametrize("subunit", ["goblin-brawler", "royal-guardian"])
+    def test_spawned_subunits_are_non_card(self, subunit):
+        """Goblin Brawler (spawned by Goblin Cage) and Royal Guardian
+        (spawned by Little Prince's Royal Rescue ability) are not card
+        plays — they should be filtered out alongside golemite/lava-pup/
+        hog rather than producing CardPlay events."""
+        assert subunit in KATACR_NON_CARD
+        assert subunit not in KATACR_TO_CARD
 
 
 class TestSnapshotCoverage:

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -99,7 +99,7 @@ class TestMappingValidity:
         """Sentinel: the set must stay empty. If a new card appears whose
         cost is genuinely unknown, add it to CARD_COSTS with a sourced
         value rather than re-populating this set."""
-        assert _KNOWN_UNCONFIRMED_COSTS == frozenset()
+        assert frozenset() == _KNOWN_UNCONFIRMED_COSTS
 
     def test_no_overlap_between_card_and_non_card(self):
         overlap = set(KATACR_TO_CARD.keys()) & KATACR_NON_CARD


### PR DESCRIPTION
Wave 1 of [Finish Clash Royale Post-Game Analyzer](SPEC.md) — data-quality validation before EV retraining (Wave 2 depends on 1A merging upstream).

## Chunks in this wave

- `swarm/finish-project-wave-1a-side-inference` — Validated `_infer_side` heuristic on 10 arena_15 replays. Findings + per-replay numbers in `docs/data-quality.md`. Heuristic was correct; no code change required.
- `swarm/finish-project-wave-1b-champion-costs` — Sourced costs for the 7 entries that were in `_KNOWN_UNCONFIRMED_COSTS`. Five are real cards now in `CARD_COSTS` (`boss_bandit`, `terry`, `rune_giant`, `spirit_empress`, `mirror`). Two were misclassified as cards and are reclassified as `KATACR_NON_CARD` subunits (`goblin-brawler` from Goblin Cage, `royal-guardian` from Little Prince). `_KNOWN_UNCONFIRMED_COSTS` is now empty. Sources cited per commit.
- `swarm/finish-project-wave-1c-yolo-pod-audit` — Audited `crpod_v1_best.pt` on 3 of the pod's own match recordings (886×1920, far from the 540×960 HF training distribution). Findings + per-card detection quality in `docs/yolo-pod-audit.md`. Towers/HUD/swarm units survive the resolution shift; `mega-knight`, `mini-pekka`, `wizard`, `giant-skeleton` produced ~0 detections even at conf=0.05. Recommendations are documented; **no fixes applied here** (per spec, the audit is a research deliverable; follow-up issues are filed separately).

## Verification

End-to-end smoke that proves we're done (from SPEC.md):

1. `crpod train --weights output/models/crpod_v1_best.pt --out output/models/ev.joblib` succeeds and prints holdout MAE + Spearman correlation against the tower-HP-delta target. — _Wave 2_
2. `crpod analyze-video <pod-replay>.mp4 --weights ... --model output/models/ev.joblib` produces `summary.json`, `blunders.json`, `placements.png`, `tempo.png`, `report.html`. — _Waves 2-4_
3. `docs/latency-budget.md` shows per-stage p50/p95/p99 on a 30-second video. — _Wave 4_
4. `scripts/smoke_arena15.sh` runs all 76 arena_15 replays end-to-end; failure rate < 5%. — _Wave 4_
5. `make lint format type-check test` passes. — **47/47 tests pass on this branch.**
6. README quickstart is copy-paste runnable; `docs/TODO.md` reflects every completed item. — _Wave 4_

This wave handles deliverable parts of (5) plus the data-quality prerequisites for (1)-(2).

---
_Generated by `/swarm`. Spec: `SPEC.md`._