### PR TITLE
feat(cli): mirror fail-fast argument validation across analyze + train

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,17 @@ jobs:
 
       - name: pytest
         run: nix develop --command uv run pytest
+
+  validate-specs:
+    name: OpenSpec validate
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate OpenSpec changes and specs
+        run: npx --yes @fission-ai/openspec@latest validate --all --strict

--- a/openspec/changes/archive/2026-05-01-cli-fail-fast-validation/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-01-cli-fail-fast-validation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/archive/2026-05-01-cli-fail-fast-validation/design.md
+++ b/openspec/changes/archive/2026-05-01-cli-fail-fast-validation/design.md
@@ -1,0 +1,77 @@
+## Context
+
+`src/crpod/__main__.py` currently has three subcommand handlers —
+`_cmd_analyze`, `_cmd_analyze_video`, `_cmd_train`. Only `_cmd_analyze_video`
+follows the project convention of validating every argument before importing
+the heavy `crpod.pipeline` module (see lines 70–88, where `analyze_video` is
+imported only after all path/numeric checks pass). The convention exists in
+code but is not yet enforced uniformly.
+
+Two unrelated issues use the same exit pattern: `_cmd_analyze` and `_cmd_train`
+use `sys.exit(f"...")` (which prints to stderr without prefix) instead of the
+explicit `print(f"error: ...", file=sys.stderr); sys.exit(1)` pattern that
+`_cmd_analyze_video` uses. We unify on the latter so the spec's "stable error
+prefix" requirement holds across all subcommands.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- All three subcommands validate filesystem and numeric arguments before any
+  heavy import.
+- All argument errors share the format: `error: <message>` to stderr, exit code 1.
+- Add a `tests/test_cli.py` with subprocess-style tests that exercise each
+  fail-fast path locally — no GPU, no Brev, no HuggingFace network access.
+
+**Non-Goals:**
+
+- Refactoring argparse types (e.g., promoting `_positive_float` to a
+  module-level helper for `--max-replays`). We could, but the diff is bigger
+  than it looks because `argparse` runs type validators *before* `func` is
+  called, and that's a different layer. Keep the validation inline.
+- Changing the exit-code convention for non-argument errors (FileNotFoundError
+  raised inside `analyze_video`, etc.). Those already use exit 1.
+- Touching `_cmd_analyze_video` — it already complies.
+
+## Decisions
+
+### Decision 1: Inline validation, not a shared helper
+
+`_cmd_analyze_video` validates inline (one block of `if ...: print/exit` per
+argument). We mirror that style in `_cmd_analyze` and `_cmd_train` rather than
+extracting a `_require_path(...)` helper. Reasons:
+
+- Three subcommands × ~3 checks each = 9 lines of repetition. Not enough mass
+  to justify abstraction.
+- Inline keeps the validation visible at the start of each handler — important
+  because the *ordering* (validation before import) is the contract.
+- Matches `openspec/config.yaml`'s "three similar lines is better than a
+  premature abstraction" guidance.
+
+### Decision 2: Validate `Path(args.out).parent` for train, not the full `--out` path
+
+`--out` is the file we'll *write*, so it shouldn't exist yet. What must exist
+is its parent directory. We use `args.out.parent.exists()` (or treat a missing
+parent as the failure). We do not auto-create it, because in `_cmd_train` the
+`--out` is the final model artifact — silently creating a parent directory
+could mask typos like `--out output/modls/foo.joblib`.
+
+Contrast with `_cmd_analyze_video`, which uses `out_dir.mkdir(parents=True,
+exist_ok=True)` because that's a directory of result artifacts where
+convenience wins.
+
+### Decision 3: `--max-replays` validated as part of subcommand handler, not as `argparse` type
+
+Adding `type=_positive_int` to the argparse declaration would surface the error
+via argparse's own format (exit code 2, not 1). To keep all argument errors on
+the spec-mandated `error: ... / exit 1` surface, we validate inside `_cmd_train`
+at the same layer as the path checks.
+
+### Decision 4: CLI tests use `subprocess.run(["python", "-m", "crpod", ...])`
+
+We invoke the CLI as a subprocess, capturing stdout/stderr/exit code. Reasons:
+
+- Lets us assert that heavy modules were *not* imported.
+- Avoids monkey-patching `sys.exit` inside pytest, which is fragile.
+- Matches how a user actually runs the CLI.
+- Tests stay local and cheap; no fixtures or HF network calls.

--- a/openspec/changes/archive/2026-05-01-cli-fail-fast-validation/proposal.md
+++ b/openspec/changes/archive/2026-05-01-cli-fail-fast-validation/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+`crpod analyze-video` already validates all path arguments before importing the
+heavy `pipeline` module, giving users a fast failure with a clear message. The
+sibling commands `crpod analyze` and `crpod train` skip this discipline:
+`--model` is never checked in `analyze`, and `train` neither validates the
+`--out` parent directory nor enforces `--max-replays > 0`. Users who mistype a
+path wait through HuggingFace dataset reads or YOLO weight loads before getting
+a far less specific error. This change closes the gap so all three CLI
+commands fail fast with consistent error messages.
+
+## What Changes
+
+- `crpod analyze` validates `--model` exists (when provided) before any pipeline
+  import.
+- `crpod train` validates that the parent directory of `--out` exists and that
+  `--max-replays > 0` before any HuggingFace loader work.
+- All three commands share the same exit conventions: stderr message prefixed
+  `error: `, exit code `1`, and validation runs *before* heavy imports.
+- Add a CLI test module (`tests/test_cli.py`) covering each fail-fast path —
+  none exist today.
+
+## Capabilities
+
+### New Capabilities
+
+- `cli`: Behavior contract for `crpod`'s argparse-driven entry points — argument
+  validation, exit codes, and ordering of validation versus heavy imports.
+
+### Modified Capabilities
+
+_(none — `openspec/specs/` is currently empty; this change introduces the first
+capability spec.)_
+
+## Impact
+
+- `src/crpod/__main__.py`: add validation guards in `_cmd_analyze` and
+  `_cmd_train`; reuse the same `print(..., file=sys.stderr); sys.exit(1)`
+  pattern already in `_cmd_analyze_video`.
+- `tests/test_cli.py`: new file with subprocess-style tests covering each
+  fail-fast path. Pure local pytest — no Brev / no GPU.
+- No new system deps in `flake.nix`, no new Python deps in `pyproject.toml`.
+- No fixtures or HuggingFace dataset reads required.

--- a/openspec/changes/archive/2026-05-01-cli-fail-fast-validation/specs/cli/spec.md
+++ b/openspec/changes/archive/2026-05-01-cli-fail-fast-validation/specs/cli/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Argument validation precedes heavy work
+
+The crpod CLI SHALL validate every argument value (file paths, output
+directories, numeric ranges) before any module that performs filesystem I/O for
+ML weights, video decoding, or HuggingFace dataset access is imported or
+invoked. This applies to all subcommands that accept such arguments.
+
+#### Scenario: Mistyped weights path on analyze
+
+- **GIVEN** the user runs the `analyze` subcommand with a `--weights` value that does not exist on disk
+- **WHEN** the CLI parses the arguments
+- **THEN** the CLI MUST exit with a non-zero status before any pipeline, dataset, or YOLO module is loaded
+- **AND** the error MUST be emitted to stderr and identify the missing weights path
+
+#### Scenario: Mistyped optional model path on analyze
+
+- **GIVEN** the user runs the `analyze` subcommand with an existing `--weights` and a `--model` value that does not exist on disk
+- **WHEN** the CLI parses the arguments
+- **THEN** the CLI MUST exit with a non-zero status before any pipeline or dataset module is loaded
+- **AND** the error MUST identify the missing model path
+
+#### Scenario: Mistyped weights path on train
+
+- **GIVEN** the user runs the `train` subcommand with a `--weights` value that does not exist on disk
+- **WHEN** the CLI parses the arguments
+- **THEN** the CLI MUST exit with a non-zero status before any HuggingFace dataset access occurs
+- **AND** the error MUST identify the missing weights path
+
+### Requirement: Output directories are validated before heavy work
+
+The crpod CLI SHALL ensure that any user-supplied output destination is
+reachable (the parent directory exists or can be created) before producing
+artifacts that take more than a few seconds to compute.
+
+#### Scenario: Train output points into a missing parent directory
+
+- **GIVEN** the user runs the `train` subcommand with `--out` whose parent directory does not exist
+- **WHEN** the CLI parses the arguments
+- **THEN** the CLI MUST exit with a non-zero status before any dataset loading occurs
+- **AND** the error MUST identify the unreachable output path
+
+### Requirement: Numeric arguments enforce positive-value preconditions
+
+The crpod CLI SHALL reject non-positive values for arguments that bound
+iteration or sampling (frames per second, replay counts) before any heavy work
+begins.
+
+#### Scenario: Non-positive max-replays on train
+
+- **GIVEN** the user runs the `train` subcommand with `--max-replays 0` (or a negative integer)
+- **WHEN** the CLI parses the arguments
+- **THEN** the CLI MUST exit with a non-zero status before any dataset loading occurs
+- **AND** the error MUST state that `--max-replays` must be greater than zero
+
+### Requirement: CLI errors share a consistent surface
+
+The crpod CLI SHALL emit user-facing argument errors to stderr using a stable
+prefix and exit code so that wrapper scripts can rely on a uniform error
+surface.
+
+#### Scenario: Argument error format
+
+- **GIVEN** any CLI invocation that fails argument validation
+- **WHEN** the CLI emits its error
+- **THEN** the message MUST be written to stderr
+- **AND** the message MUST begin with the literal prefix `error: `
+- **AND** the process MUST exit with status code `1`

--- a/openspec/changes/archive/2026-05-01-cli-fail-fast-validation/tasks.md
+++ b/openspec/changes/archive/2026-05-01-cli-fail-fast-validation/tasks.md
@@ -1,0 +1,28 @@
+## 1. `src/crpod/__main__.py` — `_cmd_analyze`
+
+- [x] 1.1 Replace `sys.exit(f"weights file not found: {args.weights}")` with the `print(f"error: weights file not found: {args.weights}", file=sys.stderr); sys.exit(1)` pattern (mirroring `_cmd_analyze_video`).
+- [x] 1.2 Add a guard for `--model`: if `args.model is not None` and `not args.model.exists()`, emit `error: EV model file not found: {args.model}` to stderr and exit 1.
+- [x] 1.3 Confirm both guards run before `EvModel.load(args.model)` and `analyze_hf_replay(...)` are called.
+
+## 2. `src/crpod/__main__.py` — `_cmd_train`
+
+- [x] 2.1 Replace `sys.exit(f"weights file not found: {args.weights}")` with the standard `error: ... / exit 1` pattern.
+- [x] 2.2 Add a guard: if `args.out.parent` does not exist, emit `error: output directory does not exist: {args.out.parent}` to stderr and exit 1.
+- [x] 2.3 Add a guard: if `args.max_replays <= 0`, emit `error: --max-replays must be > 0` to stderr and exit 1.
+- [x] 2.4 Confirm all guards run before `HFReplayLoader(...)` is constructed.
+
+## 3. `tests/test_cli.py` — new file
+
+- [x] 3.1 Create `tests/test_cli.py` with a `_run(args)` helper that subprocess-invokes `python -m crpod ...` from the repo root and returns `(returncode, stdout, stderr)`.
+- [x] 3.2 Test: `analyze` with a missing `--weights` exits 1, stderr starts with `error:` and names the missing path.
+- [x] 3.3 Test: `analyze` with valid `--weights` (use `tmp_path` to create an empty stub file) and a missing `--model` exits 1 and names the missing model path.
+- [x] 3.4 Test: `train` with a missing `--weights` exits 1 with the expected error format.
+- [x] 3.5 Test: `train` with valid `--weights` and `--out` whose parent directory does not exist exits 1 with the unreachable-output message.
+- [x] 3.6 Test: `train` with valid `--weights`, valid `--out` parent, and `--max-replays 0` exits 1 with the positive-value message.
+
+## 4. Verify
+
+- [x] 4.1 Run `nix develop --command uv run pytest tests/test_cli.py -v` and confirm all new tests pass.
+- [x] 4.2 Run `nix develop --command uv run pytest` (full suite) and confirm no regressions.
+- [x] 4.3 Run `nix develop --command uv run ruff check src tests` and `nix develop --command uv run mypy src` — confirm clean.
+- [x] 4.4 Run `openspec validate cli-fail-fast-validation` and confirm the change validates against its schema.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,77 @@
+schema: spec-driven
+
+context: |
+  Project: Clash Royale Post-Game Analyzer (crpod) — CV + statistical pipeline that
+  ingests gameplay video, detects card plays + HUD state, and produces analysis
+  artifacts (summary.json, blunders.json, report.html).
+
+  Runtime: Python 3.11 only. Dependencies managed by uv (`uv sync --frozen`).
+  The project lives behind a Nix flake — every dev/CI command runs inside
+  `nix develop` because system deps (ffmpeg, tesseract, libGL, etc.) come from
+  nixpkgs, not pip. Local compute is intentionally weak; heavy CPU/GPU work
+  (training, batch inference, dataset preparation) runs on Brev.
+
+  CV/ML stack: ultralytics YOLO for detection, supervision (ByteTrack) for
+  tracking, pytesseract for HUD OCR, torch + lightgbm for modeling, pandas +
+  pyarrow + datasets for data wrangling. Pipeline shape:
+  `VideoFrameIterator → YoloDetector → Tracker → HudReader → CardPlay/HudState
+  stream → analyze_replay`.
+
+  Source layout (`src/crpod/`): `detection/`, `tracking/`, `ocr/`, `dataset/`,
+  `features/`, `modeling/`, `visualization/`, plus `pipeline.py`, `types.py`,
+  `constants.py`, `__main__.py` (CLI: `crpod analyze`, `crpod analyze-video`).
+
+  Tests in `tests/` use pytest; lint is ruff (check + format); types are mypy
+  on `src/`. Snapshot/fixture data lives in `tests/fixtures/`.
+
+  Conventions:
+  - Run commands as `nix develop --command uv run …` (locally and in CI).
+  - Branch naming follows `swarm/{slug}-wave-{n}` for parallel work; `chore/`,
+    `fix/`, `feat/` for everything else.
+  - Code style: snake_case functions/vars, kebab-case branches/CLI flags.
+  - Prefer no comments; only add comments when WHY is non-obvious.
+  - Boundary types live in `src/crpod/types.py` — extend there before inventing.
+
+rules:
+  proposal:
+    - State which existing modules under `src/crpod/` this change touches and why.
+      This is a brownfield codebase — almost every change is a modification, not
+      a greenfield addition.
+    - Call out compute requirements explicitly. If anything in this change must
+      run on Brev (training, full-dataset eval, large batched inference), say so
+      under Scope.
+    - Identify whether this change requires new fixture data in `tests/fixtures/`
+      or new HuggingFace dataset reads — these are expensive to set up, worth
+      flagging upfront.
+
+  specs:
+    - Specs are behavior contracts. Do not name internal classes, functions, or
+      file paths in requirements/scenarios. Those belong in `design.md`.
+    - Use Given/When/Then scenarios. For pipeline stages, prefer scenarios shaped
+      around inputs (frame batches, parquet rows) and outputs (CardPlay, HudState,
+      AnalysisResult) rather than implementation steps.
+    - Organize specs by domain mirroring the source tree where it makes sense:
+      `detection/`, `tracking/`, `ocr/`, `modeling/`, `pipeline/`, `cli/`.
+    - Use SHALL/MUST for hard contracts (CLI output schema, public function
+      signatures); use SHOULD for performance/quality targets.
+
+  design:
+    - Reference existing patterns in `src/crpod/` before inventing new structure.
+      Especially: how `pipeline.py` composes stages, how `types.py` declares
+      boundary types, how `detection/cards.py` handles per-frame mapping.
+    - Declare data shapes precisely. For numpy: dtype + axis semantics. For
+      pandas/parquet: column names + dtypes. For HuggingFace datasets: which
+      fields are read.
+    - If the change adds a new pipeline stage, document the interface contract
+      (input type, output type, side effects) the same way existing stages do.
+    - Note any new system deps that need to land in `flake.nix` (rare — most
+      additions are pure Python and go in `pyproject.toml`).
+
+  tasks:
+    - Group tasks by file or module. A task should change one logical unit.
+    - Mark Brev-required tasks explicitly (e.g. "[Brev] Train …" or "[Brev] Run
+      full-dataset eval"). Do not silently assume local compute can handle them.
+    - Include a verification task per logical unit: pytest for code, snapshot
+      check for mappings, smoke run for CLI behavior.
+    - Keep scope tight — if you find yourself writing a refactor task next to a
+      feature task, that's a signal to split into two changes.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -50,8 +50,8 @@ rules:
     - Use Given/When/Then scenarios. For pipeline stages, prefer scenarios shaped
       around inputs (frame batches, parquet rows) and outputs (CardPlay, HudState,
       AnalysisResult) rather than implementation steps.
-    - Organize specs by domain mirroring the source tree where it makes sense:
-      `detection/`, `tracking/`, `ocr/`, `modeling/`, `pipeline/`, `cli/`.
+    - "Organize specs by domain mirroring the source tree where it makes sense:
+      `detection/`, `tracking/`, `ocr/`, `modeling/`, `pipeline/`, `cli/`."
     - Use SHALL/MUST for hard contracts (CLI output schema, public function
       signatures); use SHOULD for performance/quality targets.
 

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -1,0 +1,80 @@
+# cli Specification
+
+## Purpose
+
+Behavior contract for `crpod`'s argparse-driven entry points (`list-replays`,
+`analyze`, `analyze-video`, `train`): argument validation, exit codes, error
+formatting, and the ordering of validation relative to heavy imports
+(pipeline, dataset, YOLO weights). This spec governs what users see when
+invocations succeed or fail at the argument boundary; downstream pipeline
+behavior is covered by other capability specs.
+
+## Requirements
+### Requirement: Argument validation precedes heavy work
+
+The crpod CLI SHALL validate every argument value (file paths, output
+directories, numeric ranges) before any module that performs filesystem I/O for
+ML weights, video decoding, or HuggingFace dataset access is imported or
+invoked. This applies to all subcommands that accept such arguments.
+
+#### Scenario: Mistyped weights path on analyze
+
+- **GIVEN** the user runs the `analyze` subcommand with a `--weights` value that does not exist on disk
+- **WHEN** the CLI parses the arguments
+- **THEN** the CLI MUST exit with a non-zero status before any pipeline, dataset, or YOLO module is loaded
+- **AND** the error MUST be emitted to stderr and identify the missing weights path
+
+#### Scenario: Mistyped optional model path on analyze
+
+- **GIVEN** the user runs the `analyze` subcommand with an existing `--weights` and a `--model` value that does not exist on disk
+- **WHEN** the CLI parses the arguments
+- **THEN** the CLI MUST exit with a non-zero status before any pipeline or dataset module is loaded
+- **AND** the error MUST identify the missing model path
+
+#### Scenario: Mistyped weights path on train
+
+- **GIVEN** the user runs the `train` subcommand with a `--weights` value that does not exist on disk
+- **WHEN** the CLI parses the arguments
+- **THEN** the CLI MUST exit with a non-zero status before any HuggingFace dataset access occurs
+- **AND** the error MUST identify the missing weights path
+
+### Requirement: Output directories are validated before heavy work
+
+The crpod CLI SHALL ensure that any user-supplied output destination is
+reachable (the parent directory exists or can be created) before producing
+artifacts that take more than a few seconds to compute.
+
+#### Scenario: Train output points into a missing parent directory
+
+- **GIVEN** the user runs the `train` subcommand with `--out` whose parent directory does not exist
+- **WHEN** the CLI parses the arguments
+- **THEN** the CLI MUST exit with a non-zero status before any dataset loading occurs
+- **AND** the error MUST identify the unreachable output path
+
+### Requirement: Numeric arguments enforce positive-value preconditions
+
+The crpod CLI SHALL reject non-positive values for arguments that bound
+iteration or sampling (frames per second, replay counts) before any heavy work
+begins.
+
+#### Scenario: Non-positive max-replays on train
+
+- **GIVEN** the user runs the `train` subcommand with `--max-replays 0` (or a negative integer)
+- **WHEN** the CLI parses the arguments
+- **THEN** the CLI MUST exit with a non-zero status before any dataset loading occurs
+- **AND** the error MUST state that `--max-replays` must be greater than zero
+
+### Requirement: CLI errors share a consistent surface
+
+The crpod CLI SHALL emit user-facing argument errors to stderr using a stable
+prefix and exit code so that wrapper scripts can rely on a uniform error
+surface.
+
+#### Scenario: Argument error format
+
+- **GIVEN** any CLI invocation that fails argument validation
+- **WHEN** the CLI emits its error
+- **THEN** the message MUST be written to stderr
+- **AND** the message MUST begin with the literal prefix `error: `
+- **AND** the process MUST exit with status code `1`
+

--- a/src/crpod/__main__.py
+++ b/src/crpod/__main__.py
@@ -35,7 +35,11 @@ def _cmd_list(args: argparse.Namespace) -> int:
 
 def _cmd_analyze(args: argparse.Namespace) -> int:
     if not args.weights.exists():
-        sys.exit(f"weights file not found: {args.weights}")
+        print(f"error: weights file not found: {args.weights}", file=sys.stderr)
+        sys.exit(1)
+    if args.model is not None and not args.model.exists():
+        print(f"error: EV model file not found: {args.model}", file=sys.stderr)
+        sys.exit(1)
     model = EvModel.load(args.model) if args.model else None
     result = analyze_hf_replay(args.arena, args.replay_id, yolo_weights=args.weights, model=model)
     out = Path(args.out)
@@ -132,7 +136,14 @@ def _cmd_analyze_video(args: argparse.Namespace) -> int:
 
 def _cmd_train(args: argparse.Namespace) -> int:
     if not args.weights.exists():
-        sys.exit(f"weights file not found: {args.weights}")
+        print(f"error: weights file not found: {args.weights}", file=sys.stderr)
+        sys.exit(1)
+    if not args.out.parent.exists():
+        print(f"error: output directory does not exist: {args.out.parent}", file=sys.stderr)
+        sys.exit(1)
+    if args.max_replays <= 0:
+        print("error: --max-replays must be > 0", file=sys.stderr)
+        sys.exit(1)
     loader = HFReplayLoader(yolo_weights=args.weights)
     rows: list[dict] = []
     targets: list[float] = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,96 @@
+"""Argument-validation and fail-fast contract tests for the `crpod` CLI."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "crpod", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_analyze_missing_weights(tmp_path: Path) -> None:
+    missing = tmp_path / "no-weights.pt"
+    result = _run(["analyze", "arena_15", "abc123", "--weights", str(missing)])
+
+    assert result.returncode == 1
+    assert result.stderr.startswith("error: ")
+    assert "weights file not found" in result.stderr
+    assert str(missing) in result.stderr
+
+
+def test_analyze_missing_model(tmp_path: Path) -> None:
+    weights = tmp_path / "weights.pt"
+    weights.write_bytes(b"")
+    missing_model = tmp_path / "no-model.joblib"
+
+    result = _run(
+        [
+            "analyze",
+            "arena_15",
+            "abc123",
+            "--weights",
+            str(weights),
+            "--model",
+            str(missing_model),
+        ]
+    )
+
+    assert result.returncode == 1
+    assert result.stderr.startswith("error: ")
+    assert "EV model file not found" in result.stderr
+    assert str(missing_model) in result.stderr
+
+
+def test_train_missing_weights(tmp_path: Path) -> None:
+    missing = tmp_path / "no-weights.pt"
+    out = tmp_path / "model.joblib"
+
+    result = _run(["train", "--weights", str(missing), "--out", str(out)])
+
+    assert result.returncode == 1
+    assert result.stderr.startswith("error: ")
+    assert "weights file not found" in result.stderr
+    assert str(missing) in result.stderr
+
+
+def test_train_unreachable_out_parent(tmp_path: Path) -> None:
+    weights = tmp_path / "weights.pt"
+    weights.write_bytes(b"")
+    out = tmp_path / "missing-dir" / "model.joblib"
+
+    result = _run(["train", "--weights", str(weights), "--out", str(out)])
+
+    assert result.returncode == 1
+    assert result.stderr.startswith("error: ")
+    assert "output directory does not exist" in result.stderr
+    assert str(out.parent) in result.stderr
+
+
+def test_train_non_positive_max_replays(tmp_path: Path) -> None:
+    weights = tmp_path / "weights.pt"
+    weights.write_bytes(b"")
+    out = tmp_path / "model.joblib"
+
+    result = _run(
+        [
+            "train",
+            "--weights",
+            str(weights),
+            "--out",
+            str(out),
+            "--max-replays",
+            "0",
+        ]
+    )
+
+    assert result.returncode == 1
+    assert result.stderr.startswith("error: ")
+    assert "--max-replays must be > 0" in result.stderr


### PR DESCRIPTION
## Summary

- Mirror `_cmd_analyze_video`'s pre-import validation discipline in `_cmd_analyze` (now checks `--model`) and `_cmd_train` (now checks `--out` parent dir and `--max-replays > 0`). All argument errors now share one surface: `error: <msg>` on stderr, exit code 1.
- Add `tests/test_cli.py` — first CLI-level test module — covering all five fail-fast paths via `subprocess.run([sys.executable, "-m", "crpod", ...])`.
- Capture the contract in a new `cli` capability spec at `openspec/specs/cli/spec.md`, with the full lifecycle preserved in `openspec/changes/archive/2026-05-01-cli-fail-fast-validation/` (proposal, specs delta, design, tasks).
- Bonus drive-by: quote a plain-scalar continuation line in `openspec/config.yaml:54` that started with a backtick — every OpenSpec CLI invocation was printing a `YAMLParseError` stack trace.

## Test plan

- [x] `nix develop --command uv run pytest` — 52/52 pass (5 new in `test_cli.py`)
- [x] `nix develop --command uv run ruff check src tests` — clean
- [x] `nix develop --command uv run mypy src` — clean
- [x] `openspec validate cli-fail-fast-validation` (pre-archive) — valid
- [x] `openspec validate --specs cli` (post-archive) — valid
- [x] Manual: `openspec list` no longer emits a YAML parse error