### PR TITLE
Finish Clash Royale Post-Game Analyzer: wave 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ output/
 # Third-party data clones (large, not ours to version)
 Clash-Royale-Detection-Dataset/
 
+# Pod-local match videos / data caches (large, not versioned)
+data/
+
 # YOLO weights (large binaries — store in output/models/)
 *.pt
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -157,3 +157,5 @@ Fork remote: origin
 Upstream remote: origin
 
 _Wave 1 executed 2026-05-01 on branch swarm/finish-project-wave-1; chunks 1a-side-inference, 1b-champion-costs, 1c-yolo-pod-audit; PR https://github.com/max-miller1204/Clash-Royale-Pod/pull/24_
+
+_Wave 2 executed 2026-05-01 on branch swarm/finish-project-wave-2; chunks 2a-ev-label, 2b-retrain-validate; PR https://github.com/max-miller1204/Clash-Royale-Pod/pull/26_

--- a/docs/ev-validation.md
+++ b/docs/ev-validation.md
@@ -39,26 +39,41 @@ never enters version control.
 
 ## Run results
 
-> **Status: structural deliverable only — metrics pending a real
-> training run.**
+> **Status: structural deliverable only — metrics blocked by a wave-2A
+> scoping miss in `src/crpod/dataset/huggingface.py`.**
 >
-> Two environment gaps blocked executing the run inside this worktree:
+> A real run was attempted on a brev A6000 instance (`hyperstack_A6000`,
+> Python 3.11 venv, `torch==2.11.0+cu126` against driver 570 / CUDA
+> 12.8). End-to-end command exited cleanly:
 >
-> 1. **`scikit-learn` is not in `pyproject.toml`.** LightGBM's
->    `LGBMRegressor` (sklearn API) raises `LightGBMError: scikit-learn
->    is required for lightgbm.sklearn` at fit time. `pyproject.toml` is
->    outside this chunk's owned files (per `CHUNK.md` ground rule 2),
->    so I'm surfacing rather than silently editing.
-> 2. **Local box has very low compute power.** Per `CLAUDE.md`, heavy
->    pipelines (YOLO inference on HF replay frames) should run on
->    `brev`. Even a `--max-replays 5` smoke run on macOS CPU is
->    untested and likely impractical.
+> ```text
+> dropped 768/768 training rows (100% — unreadable HUD)
+> no training data collected
+> ```
 >
-> The chunk's compute notes call out three lanes: (a) reduced
-> `--max-replays` smoke run, (b) brev for the full retrain, (c) stop
-> and surface. We're at lane (c) until the user picks (a) or (b).
-
-Once a run lands, fill in:
+> **Diagnosis.** `HFReplayLoader.load` returns `Replay(..., hud=[])`
+> at `src/crpod/dataset/huggingface.py:127`. Wave-2A's
+> `_training_target` (in `src/crpod/__main__.py`) requires
+> `interaction.tower_hp_delta` to be fully populated, which requires
+> `Interaction` windows built from a non-empty `Replay.hud`
+> (`crpod.features.interactions.build_interactions` reads HUD frames
+> at the window endpoints). With an empty `hud` list every interaction
+> hits the `None` branch in `_training_target` and gets dropped — 100%
+> of rows.
+>
+> **Why this didn't fail wave-2A's tests.** `tests/test_ev_target.py`
+> constructs `HudState`/`Interaction` instances synthetically in pure
+> Python (see the `_hud()` and `_interaction()` helpers), so the unit
+> tests exercise only the label arithmetic — they never hit the HF
+> loader. The gap is invisible until an end-to-end retrain.
+>
+> **Why this chunk can't fix it.** `src/crpod/dataset/*` is explicitly
+> out of scope for wave-2B per `CHUNK.md` ("Out of scope (do NOT
+> touch)"). Wiring `crpod.ocr.hud.HudReader` into `_parquet_to_replay`
+> belongs to a follow-up chunk (call it wave-2C "HUD-on-HF") or a
+> retroactive amendment to wave-2A.
+>
+> When that lands, fill in:
 
 | Metric                    | Value |
 | ------------------------- | ----- |

--- a/docs/ev-validation.md
+++ b/docs/ev-validation.md
@@ -1,0 +1,108 @@
+# EV Model Validation — Wave 2B
+
+## Target
+
+`EvModel` is now trained against the **princess-tower HP delta** target
+(`(friendly_left + friendly_right) - (enemy_left + enemy_right)` per
+`_training_target` in `src/crpod/__main__.py`), replacing the prior
+`elixir_trade` proxy. Sign convention: positive = our towers came out
+ahead in the interaction window.
+
+## Holdout protocol
+
+- Split unit: **replay**, not row. All interactions from one replay land
+  in the same fold so adjacent-frame leakage doesn't inflate the score.
+- 80% train / 20% holdout; deterministic via `random.Random(0)` shuffle.
+- `per_card_stats` (median, std of training-fold targets, anchored on
+  `Interaction.friendly_plays[0].card`) is computed from the **training
+  fold only**. Cards with fewer than five training-fold samples are
+  excluded so wave 3's blunder rule reduces to a key check.
+- Holdout metrics: MAE = `mean(|pred - true|)`; Spearman correlation via
+  `scipy.stats.spearmanr`.
+
+## How to reproduce
+
+```bash
+nix develop -c bash -c '
+  uv run crpod train \
+    --weights output/models/crpod_v1_best.pt \
+    --out output/models/ev.joblib \
+    --max-replays 50
+'
+```
+
+`_cmd_train` prints, in order: drop-rate (HUD-unreadable rows, from
+wave 2A), train sample count, holdout sample count, holdout MAE,
+holdout Spearman, and the saved-model path. The artifact lands at
+`output/models/ev.joblib`; `output/` is gitignored, so the binary
+never enters version control.
+
+## Run results
+
+> **Status: structural deliverable only — metrics pending a real
+> training run.**
+>
+> Two environment gaps blocked executing the run inside this worktree:
+>
+> 1. **`scikit-learn` is not in `pyproject.toml`.** LightGBM's
+>    `LGBMRegressor` (sklearn API) raises `LightGBMError: scikit-learn
+>    is required for lightgbm.sklearn` at fit time. `pyproject.toml` is
+>    outside this chunk's owned files (per `CHUNK.md` ground rule 2),
+>    so I'm surfacing rather than silently editing.
+> 2. **Local box has very low compute power.** Per `CLAUDE.md`, heavy
+>    pipelines (YOLO inference on HF replay frames) should run on
+>    `brev`. Even a `--max-replays 5` smoke run on macOS CPU is
+>    untested and likely impractical.
+>
+> The chunk's compute notes call out three lanes: (a) reduced
+> `--max-replays` smoke run, (b) brev for the full retrain, (c) stop
+> and surface. We're at lane (c) until the user picks (a) or (b).
+
+Once a run lands, fill in:
+
+| Metric                    | Value |
+| ------------------------- | ----- |
+| Replays processed         | TBD   |
+| Drop rate (unreadable HUD)| TBD   |
+| Total interactions        | TBD   |
+| Train sample count        | TBD   |
+| Holdout sample count      | TBD   |
+| Holdout MAE               | TBD   |
+| Holdout Spearman ρ        | TBD   |
+| Run mode (full / smoke)   | TBD   |
+
+### Top-10 most-frequent cards (training fold)
+
+Anchor card = `Interaction.friendly_plays[0].card`. Cards with fewer
+than five training-fold samples are excluded from `per_card_stats`.
+
+| Rank | Card | n_samples | median target | std target |
+| ---- | ---- | --------- | ------------- | ---------- |
+| 1    | TBD  | TBD       | TBD           | TBD        |
+| ...  | ...  | ...       | ...           | ...        |
+
+### Interpretation
+
+> One paragraph here once metrics land: is the new tower-HP-delta
+> target better than the old `elixir_trade` proxy? Specifically — is
+> holdout Spearman positive and meaningfully above zero, and is MAE
+> small relative to the natural per-tower HP scale (princess towers
+> start at ~3000 HP, so MAE in the few-hundreds range would be
+> respectable; MAE comparable to that scale would mean the model is
+> roughly guessing the mean)?
+
+## Wave-3 contract published by this chunk
+
+`EvModel.load(path).per_card_stats` returns
+`dict[str, tuple[float, float]]`:
+
+- key — card name string, matches `CardPlay.card`.
+- value — `(median, std)` of training-fold tower-HP-delta targets for
+  interactions whose anchor friendly play is that card.
+- cards with `<5` training-fold samples are absent from the dict, so
+  wave 3A's "skip cards with insufficient samples" rule is a key
+  membership check.
+
+`tests/test_ev_model.py::test_save_load_round_trip` pins the
+joblib round-trip; `test_compute_per_card_stats_excludes_low_sample_cards`
+pins the `<5` exclusion.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pandas>=2.2",
     "pyarrow>=17",
     "pytesseract>=0.3.13",
+    "scikit-learn>=1.5",
     "scipy>=1.14",
     "seaborn>=0.13.2",
     "statsmodels>=0.14",

--- a/src/crpod/__main__.py
+++ b/src/crpod/__main__.py
@@ -11,13 +11,17 @@ from __future__ import annotations
 
 import argparse
 import json
+import random
 import sys
 from pathlib import Path
 
 from crpod.dataset.huggingface import HFReplayLoader
-from crpod.modeling.ev import EvModel
+from crpod.modeling.ev import EvModel, compute_per_card_stats
 from crpod.pipeline import analyze_hf_replay, analyze_replay
 from crpod.types import Interaction
+
+_HOLDOUT_SEED = 0
+_HOLDOUT_FRACTION = 0.2
 
 
 def _training_target(interaction: Interaction) -> float | None:
@@ -162,34 +166,87 @@ def _cmd_train(args: argparse.Namespace) -> int:
         print("error: --max-replays must be > 0", file=sys.stderr)
         sys.exit(1)
     loader = HFReplayLoader(yolo_weights=args.weights)
-    rows: list[dict] = []
-    targets: list[float] = []
+    # Each entry is a per-replay bundle so we can split at the replay level
+    # and avoid adjacent-frame leakage across folds.
+    per_replay: list[tuple[list[dict], list[float], list[Interaction]]] = []
     seen = 0
     dropped = 0
     available = loader.list_replays(arena=args.arena)[: args.max_replays]
     for arena, replay_id in available:
         replay = loader.load(arena, replay_id)
         result = analyze_replay(replay)
+        rep_rows: list[dict] = []
+        rep_targets: list[float] = []
+        rep_interactions: list[Interaction] = []
         for interaction, row in zip(result.interactions, result.feature_rows, strict=True):
             seen += 1
             target = _training_target(interaction)
             if target is None:
                 dropped += 1
                 continue
-            rows.append(row)
-            targets.append(target)
+            rep_rows.append(row)
+            rep_targets.append(target)
+            rep_interactions.append(interaction)
+        if rep_rows:
+            per_replay.append((rep_rows, rep_targets, rep_interactions))
     if seen:
         pct = round(100 * dropped / seen)
         print(
             f"dropped {dropped}/{seen} training rows ({pct}% — unreadable HUD)",
             file=sys.stderr,
         )
-    if not rows:
+    if not per_replay:
         print("no training data collected", file=sys.stderr)
         return 1
-    print(f"training on {len(rows)} interactions from {len(available)} replays")
+
+    rng = random.Random(_HOLDOUT_SEED)
+    shuffled = list(per_replay)
+    rng.shuffle(shuffled)
+    n_replays = len(shuffled)
+    if n_replays >= 2:
+        split_idx = max(1, min(n_replays - 1, round(n_replays * (1 - _HOLDOUT_FRACTION))))
+    else:
+        split_idx = n_replays  # nothing to hold out — single replay
+    train_bundle = shuffled[:split_idx]
+    holdout_bundle = shuffled[split_idx:]
+
+    train_rows: list[dict] = []
+    train_targets: list[float] = []
+    train_interactions: list[Interaction] = []
+    for r, t, i in train_bundle:
+        train_rows.extend(r)
+        train_targets.extend(t)
+        train_interactions.extend(i)
+    holdout_rows: list[dict] = []
+    holdout_targets: list[float] = []
+    for r, t, _ in holdout_bundle:
+        holdout_rows.extend(r)
+        holdout_targets.extend(t)
+
+    print(
+        f"training on {len(train_rows)} interactions from {len(train_bundle)} replays "
+        f"(holdout {len(holdout_rows)} interactions from {len(holdout_bundle)} replays)"
+    )
     model = EvModel()
-    model.fit(rows, targets)
+    model.fit(train_rows, train_targets)
+    model.per_card_stats = compute_per_card_stats(train_interactions, train_targets)
+    print(f"per_card_stats: {len(model.per_card_stats)} cards with ≥5 train samples")
+
+    if holdout_rows:
+        from scipy.stats import spearmanr
+
+        preds = model.predict(holdout_rows)
+        mae = sum(abs(p - t) for p, t in zip(preds, holdout_targets, strict=True)) / len(
+            holdout_targets
+        )
+        spearman_result = spearmanr(preds, holdout_targets)
+        rho = float(spearman_result.statistic)
+        print(f"holdout MAE: {mae:.2f}")
+        print(f"holdout Spearman: {rho:.3f}")
+    else:
+        print("holdout MAE: n/a (single-replay training set)", file=sys.stderr)
+        print("holdout Spearman: n/a (single-replay training set)", file=sys.stderr)
+
     model.save(Path(args.out))
     print(f"saved model → {args.out}")
     return 0

--- a/src/crpod/__main__.py
+++ b/src/crpod/__main__.py
@@ -232,6 +232,23 @@ def _cmd_train(args: argparse.Namespace) -> int:
     model.per_card_stats = compute_per_card_stats(train_interactions, train_targets)
     print(f"per_card_stats: {len(model.per_card_stats)} cards with ≥5 train samples")
 
+    # Top-10 anchor cards by training-fold sample count (for docs/ev-validation.md).
+    counts: dict[str, int] = {}
+    for interaction in train_interactions:
+        if not interaction.friendly_plays:
+            continue
+        counts[interaction.friendly_plays[0].card] = (
+            counts.get(interaction.friendly_plays[0].card, 0) + 1
+        )
+    top = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:10]
+    print("top-10 anchor cards by train-fold n_samples:")
+    for card, n in top:
+        if card in model.per_card_stats:
+            median, std = model.per_card_stats[card]
+            print(f"  {card}: n={n} median={median:+.1f} std={std:.1f}")
+        else:
+            print(f"  {card}: n={n} (excluded — <5 samples)")
+
     if holdout_rows:
         from scipy.stats import spearmanr
 

--- a/src/crpod/__main__.py
+++ b/src/crpod/__main__.py
@@ -17,6 +17,23 @@ from pathlib import Path
 from crpod.dataset.huggingface import HFReplayLoader
 from crpod.modeling.ev import EvModel
 from crpod.pipeline import analyze_hf_replay, analyze_replay
+from crpod.types import Interaction
+
+
+def _training_target(interaction: Interaction) -> float | None:
+    """Princess-tower HP-delta EV target for one interaction.
+
+    Returns `None` when any of the four princess deltas is unreadable so
+    callers can drop the row.
+    """
+    delta = interaction.tower_hp_delta
+    fl = delta.get("friendly_left")
+    fr = delta.get("friendly_right")
+    el = delta.get("enemy_left")
+    er = delta.get("enemy_right")
+    if fl is None or fr is None or el is None or er is None:
+        return None
+    return float((fl + fr) - (el + er))
 
 
 def _positive_float(value: str) -> float:
@@ -147,13 +164,26 @@ def _cmd_train(args: argparse.Namespace) -> int:
     loader = HFReplayLoader(yolo_weights=args.weights)
     rows: list[dict] = []
     targets: list[float] = []
+    seen = 0
+    dropped = 0
     available = loader.list_replays(arena=args.arena)[: args.max_replays]
     for arena, replay_id in available:
         replay = loader.load(arena, replay_id)
         result = analyze_replay(replay)
         for interaction, row in zip(result.interactions, result.feature_rows, strict=True):
+            seen += 1
+            target = _training_target(interaction)
+            if target is None:
+                dropped += 1
+                continue
             rows.append(row)
-            targets.append(float(interaction.elixir_trade))
+            targets.append(target)
+    if seen:
+        pct = round(100 * dropped / seen)
+        print(
+            f"dropped {dropped}/{seen} training rows ({pct}% — unreadable HUD)",
+            file=sys.stderr,
+        )
     if not rows:
         print("no training data collected", file=sys.stderr)
         return 1

--- a/src/crpod/features/ev_target.py
+++ b/src/crpod/features/ev_target.py
@@ -1,0 +1,55 @@
+"""Tower-HP-delta EV target.
+
+Replaces the original `interaction.elixir_trade` proxy with a direct
+measurement of HP swing across the interaction window. Used by the EV
+training loop in `crpod.__main__._cmd_train` (wave 2A) and consumed by the
+EV-validation step (wave 2B).
+
+Sign convention: every delta is `end_hp - start_hp`. Negative means HP was
+lost over the window. Friendly losing tower HP is bad; enemy losing tower HP
+is good. The EV target sums (friendly_delta - enemy_delta) across the two
+princess towers per side.
+"""
+
+from __future__ import annotations
+
+from crpod.types import HudState
+
+_TOWER_KEYS: tuple[str, ...] = (
+    "friendly_left",
+    "friendly_right",
+    "enemy_left",
+    "enemy_right",
+)
+
+
+def _hp_for(state: HudState, key: str) -> int | None:
+    if key == "friendly_left":
+        return state.friendly_left_princess_hp
+    if key == "friendly_right":
+        return state.friendly_right_princess_hp
+    if key == "enemy_left":
+        return state.enemy_left_princess_hp
+    if key == "enemy_right":
+        return state.enemy_right_princess_hp
+    raise KeyError(key)
+
+
+def tower_hp_delta(window: list[HudState]) -> dict[str, int | None]:
+    """Per-tower princess HP swing across the window.
+
+    Returns one entry per tower keyed by `{friendly,enemy}_{left,right}`.
+    Each value is `end_hp - start_hp` for that tower, or `None` if either
+    bookend HUD reading was unreadable. An empty `window` yields `None` for
+    every tower.
+    """
+    if not window:
+        return dict.fromkeys(_TOWER_KEYS)
+    start = window[0]
+    end = window[-1]
+    out: dict[str, int | None] = {}
+    for key in _TOWER_KEYS:
+        s = _hp_for(start, key)
+        e = _hp_for(end, key)
+        out[key] = (e - s) if (s is not None and e is not None) else None
+    return out

--- a/src/crpod/features/interactions.py
+++ b/src/crpod/features/interactions.py
@@ -8,15 +8,26 @@ drops at frame N+8, both resolve by N+40 → one interaction, 4-4 elixir trade.
 from __future__ import annotations
 
 from crpod.constants import card_cost
-from crpod.types import CardPlay, Interaction, Side
+from crpod.features.ev_target import tower_hp_delta
+from crpod.types import CardPlay, HudState, Interaction, Side
 
 DEFAULT_WINDOW_FRAMES: int = 40  # ~4 seconds at 10 fps
 
 
+def _hud_window(hud: list[HudState], start_frame: int, end_frame: int) -> list[HudState]:
+    return [s for s in hud if start_frame <= s.frame <= end_frame]
+
+
 def build_interactions(
-    plays: list[CardPlay], window: int = DEFAULT_WINDOW_FRAMES
+    plays: list[CardPlay],
+    window: int = DEFAULT_WINDOW_FRAMES,
+    hud: list[HudState] | None = None,
 ) -> list[Interaction]:
-    """Greedy windowing: each play opens an interaction if none is active."""
+    """Greedy windowing: each play opens an interaction if none is active.
+
+    When `hud` is provided, each interaction's `tower_hp_delta` is populated
+    from the HudState bookends inside that interaction's frame window.
+    """
     if not plays:
         return []
 
@@ -34,14 +45,19 @@ def build_interactions(
 
         friendly = tuple(p for p in bucket if p.side is Side.FRIENDLY)
         enemy = tuple(p for p in bucket if p.side is Side.ENEMY)
+        end_frame = max(p.frame for p in bucket)
+        delta: dict[str, int | None] = {}
+        if hud is not None:
+            delta = tower_hp_delta(_hud_window(hud, anchor.frame, end_frame))
         out.append(
             Interaction(
                 start_frame=anchor.frame,
-                end_frame=max(p.frame for p in bucket),
+                end_frame=end_frame,
                 friendly_plays=friendly,
                 enemy_plays=enemy,
                 friendly_elixir_spent=sum(p.elixir_cost or card_cost(p.card) for p in friendly),
                 enemy_elixir_spent=sum(p.elixir_cost or card_cost(p.card) for p in enemy),
+                tower_hp_delta=delta,
             )
         )
         i = j

--- a/src/crpod/modeling/__init__.py
+++ b/src/crpod/modeling/__init__.py
@@ -1,5 +1,5 @@
 """EV modeling — LightGBM over engineered features."""
 
-from crpod.modeling.ev import EvModel, interaction_features
+from crpod.modeling.ev import EvModel, compute_per_card_stats, interaction_features
 
-__all__ = ["EvModel", "interaction_features"]
+__all__ = ["EvModel", "compute_per_card_stats", "interaction_features"]

--- a/src/crpod/modeling/ev.py
+++ b/src/crpod/modeling/ev.py
@@ -1,13 +1,15 @@
 """Expected-value model.
 
-Training target: per-interaction elixir trade + damage delta (a proxy for
-win-probability shift). Features: cards played, placement zones, tempo,
-elixir state at interaction start.
+Training target: per-interaction princess-tower HP delta — see `_training_target`
+in `crpod.__main__`. Features: cards played, placement zones, tempo, elixir
+state at interaction start.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import statistics
+from collections.abc import Sequence
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -33,12 +35,37 @@ def interaction_features(interaction: Interaction) -> dict[str, Any]:
     }
 
 
+def compute_per_card_stats(
+    interactions: Sequence[Interaction],
+    targets: Sequence[float],
+    min_samples: int = 5,
+) -> dict[str, tuple[float, float]]:
+    """Group targets by anchor friendly card and return (median, std) per card.
+
+    The anchor is `interaction.friendly_plays[0].card`; rows with empty
+    `friendly_plays` contribute no per-card sample. Cards with fewer than
+    `min_samples` training-fold rows are excluded.
+    """
+    by_card: dict[str, list[float]] = {}
+    for interaction, target in zip(interactions, targets, strict=True):
+        if not interaction.friendly_plays:
+            continue
+        anchor = interaction.friendly_plays[0].card
+        by_card.setdefault(anchor, []).append(float(target))
+    return {
+        card: (statistics.median(values), statistics.pstdev(values))
+        for card, values in by_card.items()
+        if len(values) >= min_samples
+    }
+
+
 @dataclass
 class EvModel:
     """Thin LightGBM wrapper. Training/predict are lazy — the pipeline can
     import and flow data through features even without LightGBM installed."""
 
     model: Any = None
+    per_card_stats: dict[str, tuple[float, float]] = field(default_factory=dict)
 
     def fit(self, rows: list[dict[str, Any]], target: list[float]) -> None:
         import lightgbm as lgb
@@ -67,10 +94,24 @@ class EvModel:
             raise RuntimeError("nothing to save")
         import joblib
 
-        joblib.dump(self.model, path)
+        joblib.dump(
+            {"model": self.model, "per_card_stats": self.per_card_stats},
+            path,
+        )
 
     @classmethod
     def load(cls, path: Path) -> EvModel:
         import joblib
 
-        return cls(model=joblib.load(path))
+        payload = joblib.load(path)
+        # Tolerate the pre-2b artifact format (raw LGBMRegressor) for any
+        # checkpoint saved before per_card_stats was wired up.
+        if isinstance(payload, dict) and "model" in payload:
+            raw_stats = payload.get("per_card_stats") or {}
+            return cls(
+                model=payload["model"],
+                per_card_stats={
+                    card: (float(v[0]), float(v[1])) for card, v in raw_stats.items()
+                },
+            )
+        return cls(model=payload)

--- a/src/crpod/modeling/ev.py
+++ b/src/crpod/modeling/ev.py
@@ -35,6 +35,24 @@ def interaction_features(interaction: Interaction) -> dict[str, Any]:
     }
 
 
+def _frame_with_categoricals(rows: list[dict[str, Any]]) -> Any:
+    """Build a DataFrame from feature rows with string columns coerced to
+    object-backed `category` dtype.
+
+    pandas 3.0 made string columns default to `StringDtype`, and a category
+    whose categories are str-dtyped trips LightGBM's "must be int/float/bool
+    or category" guard. Forcing strings to plain object first keeps the
+    resulting category compatible with LightGBM 4.x.
+    """
+    import pandas as pd
+
+    df = pd.DataFrame(rows)
+    for c in df.columns:
+        if pd.api.types.is_object_dtype(df[c]) or pd.api.types.is_string_dtype(df[c]):
+            df[c] = df[c].astype(object).astype("category")
+    return df
+
+
 def compute_per_card_stats(
     interactions: Sequence[Interaction],
     targets: Sequence[float],
@@ -69,24 +87,16 @@ class EvModel:
 
     def fit(self, rows: list[dict[str, Any]], target: list[float]) -> None:
         import lightgbm as lgb
-        import pandas as pd
 
-        df = pd.DataFrame(rows)
-        categorical = [c for c in df.columns if df[c].dtype == object]
-        for c in categorical:
-            df[c] = df[c].astype("category")
+        df = _frame_with_categoricals(rows)
+        categorical = [c for c, dt in df.dtypes.items() if str(dt) == "category"]
         self.model = lgb.LGBMRegressor(n_estimators=200, learning_rate=0.05)
         self.model.fit(df, target, categorical_feature=categorical)
 
     def predict(self, rows: list[dict[str, Any]]) -> list[float]:
         if self.model is None:
             raise RuntimeError("EvModel.fit must be called before predict")
-        import pandas as pd
-
-        df = pd.DataFrame(rows)
-        for c in df.columns:
-            if df[c].dtype == object:
-                df[c] = df[c].astype("category")
+        df = _frame_with_categoricals(rows)
         return list(self.model.predict(df))
 
     def save(self, path: Path) -> None:

--- a/src/crpod/modeling/ev.py
+++ b/src/crpod/modeling/ev.py
@@ -120,8 +120,6 @@ class EvModel:
             raw_stats = payload.get("per_card_stats") or {}
             return cls(
                 model=payload["model"],
-                per_card_stats={
-                    card: (float(v[0]), float(v[1])) for card, v in raw_stats.items()
-                },
+                per_card_stats={card: (float(v[0]), float(v[1])) for card, v in raw_stats.items()},
             )
         return cls(model=payload)

--- a/src/crpod/ocr/hud.py
+++ b/src/crpod/ocr/hud.py
@@ -49,12 +49,22 @@ class HudReader:
         self._lazy_load()
         friendly_elixir = self._read_number(frame, self.regions.friendly_elixir)
         enemy_elixir = self._read_number(frame, self.regions.enemy_elixir)
+        # Princess-tower HP regions are tuned in `HudRegions`; king-HP rects
+        # are still rough (see `docs/TODO.md`), so leave king HP `None` here.
+        friendly_left = self._read_number(frame, self.regions.friendly_tower_left)
+        friendly_right = self._read_number(frame, self.regions.friendly_tower_right)
+        enemy_left = self._read_number(frame, self.regions.enemy_tower_left)
+        enemy_right = self._read_number(frame, self.regions.enemy_tower_right)
         return HudState(
             frame=frame_idx,
             friendly_elixir=float(friendly_elixir or 0),
             enemy_elixir=float(enemy_elixir) if enemy_elixir is not None else None,
             friendly_king_hp=None,
             enemy_king_hp=None,
+            friendly_left_princess_hp=friendly_left,
+            friendly_right_princess_hp=friendly_right,
+            enemy_left_princess_hp=enemy_left,
+            enemy_right_princess_hp=enemy_right,
         )
 
     def _read_number(self, frame: np.ndarray, region: tuple[int, int, int, int]) -> int | None:

--- a/src/crpod/pipeline.py
+++ b/src/crpod/pipeline.py
@@ -98,7 +98,7 @@ class AnalysisResult:
 
 
 def analyze_replay(replay: Replay, model: EvModel | None = None) -> AnalysisResult:
-    interactions = build_interactions(replay.plays)
+    interactions = build_interactions(replay.plays, hud=replay.hud)
     rows = [interaction_features(i) for i in interactions]
     predictions = model.predict(rows) if (model and rows) else None
     return AnalysisResult(

--- a/src/crpod/types.py
+++ b/src/crpod/types.py
@@ -30,15 +30,23 @@ class CardPlay:
 
 @dataclass(frozen=True)
 class HudState:
-    """Per-frame HUD reading."""
+    """Per-frame HUD reading.
+
+    Tower-HP fields are flat (left/right rather than tuples) so the EV target
+    builder in `crpod.features.ev_target` can name each tower in its output
+    dict without index ceremony. King HP is read separately because
+    `HudRegions.{friendly,enemy}_king` is still rough — see `docs/TODO.md`.
+    """
 
     frame: int
     friendly_elixir: float
     enemy_elixir: float | None
-    friendly_king_hp: int | None
-    enemy_king_hp: int | None
-    friendly_princess_hp: tuple[int | None, int | None] = (None, None)
-    enemy_princess_hp: tuple[int | None, int | None] = (None, None)
+    friendly_king_hp: int | None = None
+    enemy_king_hp: int | None = None
+    friendly_left_princess_hp: int | None = None
+    friendly_right_princess_hp: int | None = None
+    enemy_left_princess_hp: int | None = None
+    enemy_right_princess_hp: int | None = None
 
 
 @dataclass
@@ -65,6 +73,11 @@ class Interaction:
     enemy_elixir_spent: int
     damage_dealt: int = 0
     damage_taken: int = 0
+    # Per-side, per-tower princess HP swing across the interaction window.
+    # Keys: "friendly_left", "friendly_right", "enemy_left", "enemy_right".
+    # Value sign convention: end_hp - start_hp (negative = HP lost).
+    # `None` for any tower whose start- or end-frame HUD reading was unreadable.
+    tower_hp_delta: dict[str, int | None] = field(default_factory=dict)
 
     @property
     def elixir_trade(self) -> int:

--- a/tests/test_ev_model.py
+++ b/tests/test_ev_model.py
@@ -1,0 +1,109 @@
+"""Round-trip tests for `EvModel.per_card_stats`.
+
+The wave-3 blunder rule keys off `per_card_stats` to skip cards with too
+few training-fold samples. These tests pin down the contract:
+
+- per-card stats are populated from the **anchor** friendly play
+  (`Interaction.friendly_plays[0].card`).
+- cards with fewer than 5 training-fold samples are excluded.
+- the dict round-trips through `save`/`load`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from crpod.modeling.ev import (
+    EvModel,
+    compute_per_card_stats,
+    interaction_features,
+)
+from crpod.types import CardPlay, Interaction, Side
+
+
+def _interaction(card: str, frame: int) -> Interaction:
+    play = CardPlay(frame=frame, card=card, x=270, y=480, side=Side.FRIENDLY)
+    return Interaction(
+        start_frame=frame,
+        end_frame=frame + 30,
+        friendly_plays=(play,),
+        enemy_plays=(),
+        friendly_elixir_spent=play.elixir_cost,
+        enemy_elixir_spent=0,
+    )
+
+
+def test_compute_per_card_stats_excludes_low_sample_cards() -> None:
+    interactions = [_interaction("knight", i) for i in range(5)] + [
+        _interaction("musketeer", 100),
+        _interaction("musketeer", 130),
+    ]
+    targets = [10.0, 20.0, 30.0, 40.0, 50.0, 5.0, 15.0]
+
+    stats = compute_per_card_stats(interactions, targets)
+
+    assert "knight" in stats
+    assert "musketeer" not in stats  # only 2 samples
+    median, std = stats["knight"]
+    assert median == pytest.approx(30.0)
+    assert std > 0
+
+
+def test_compute_per_card_stats_skips_empty_friendly_plays() -> None:
+    empty = Interaction(
+        start_frame=0,
+        end_frame=30,
+        friendly_plays=(),
+        enemy_plays=(),
+        friendly_elixir_spent=0,
+        enemy_elixir_spent=0,
+    )
+    interactions = [empty] + [_interaction("knight", i) for i in range(5)]
+    targets = [99.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+
+    stats = compute_per_card_stats(interactions, targets)
+
+    assert "knight" in stats
+    assert stats["knight"][0] == pytest.approx(3.0)
+
+
+def test_save_load_round_trip(tmp_path: Path) -> None:
+    # `importorskip` only catches ImportError; lightgbm on macOS without libomp
+    # raises OSError during dlopen. LightGBM's sklearn API also needs scikit-learn
+    # at fit time and raises LightGBMError if it's missing.
+    try:
+        import lightgbm  # noqa: F401
+    except (ImportError, OSError) as e:
+        pytest.skip(f"lightgbm unavailable: {e}")
+    pytest.importorskip("pandas")
+    pytest.importorskip("sklearn")
+
+    interactions = [_interaction("knight", i) for i in range(6)] + [
+        _interaction("musketeer", 200),
+        _interaction("musketeer", 230),
+    ]
+    targets = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 1.0, 2.0]
+    rows = [interaction_features(i) for i in interactions]
+
+    model = EvModel()
+    model.fit(rows, targets)
+    model.per_card_stats = compute_per_card_stats(interactions, targets)
+    assert "knight" in model.per_card_stats
+    assert "musketeer" not in model.per_card_stats
+
+    out = tmp_path / "ev.joblib"
+    model.save(out)
+
+    loaded = EvModel.load(out)
+    assert loaded.per_card_stats.keys() == model.per_card_stats.keys()
+    for card, (median, std) in model.per_card_stats.items():
+        loaded_median, loaded_std = loaded.per_card_stats[card]
+        assert loaded_median == pytest.approx(median)
+        assert loaded_std == pytest.approx(std)
+    # value type contract: tuple[float, float]
+    sample = next(iter(loaded.per_card_stats.values()))
+    assert isinstance(sample, tuple)
+    assert len(sample) == 2
+    assert all(isinstance(v, float) for v in sample)

--- a/tests/test_ev_target.py
+++ b/tests/test_ev_target.py
@@ -1,0 +1,91 @@
+"""Unit tests for the princess-tower HP-delta EV target.
+
+Pure-Python construction of HudState/Interaction so this runs without GPU,
+YOLO, or tesseract — exercises only the label math used by `_cmd_train`.
+"""
+
+from __future__ import annotations
+
+from crpod.__main__ import _training_target
+from crpod.features.ev_target import tower_hp_delta
+from crpod.types import HudState, Interaction
+
+
+def _hud(
+    frame: int,
+    fl: int | None = 1000,
+    fr: int | None = 1000,
+    el: int | None = 1000,
+    er: int | None = 1000,
+) -> HudState:
+    return HudState(
+        frame=frame,
+        friendly_elixir=0.0,
+        enemy_elixir=None,
+        friendly_left_princess_hp=fl,
+        friendly_right_princess_hp=fr,
+        enemy_left_princess_hp=el,
+        enemy_right_princess_hp=er,
+    )
+
+
+def _interaction(window: list[HudState]) -> Interaction:
+    return Interaction(
+        start_frame=window[0].frame,
+        end_frame=window[-1].frame,
+        friendly_plays=(),
+        enemy_plays=(),
+        friendly_elixir_spent=0,
+        enemy_elixir_spent=0,
+        tower_hp_delta=tower_hp_delta(window),
+    )
+
+
+def test_friendly_left_loss_yields_negative_target() -> None:
+    window = [
+        _hud(0, fl=1000, fr=1000, el=1000, er=1000),
+        _hud(40, fl=800, fr=1000, el=1000, er=1000),
+    ]
+    assert _training_target(_interaction(window)) == -200.0
+
+
+def test_enemy_right_loss_yields_positive_target() -> None:
+    window = [
+        _hud(0, fl=1000, fr=1000, el=1000, er=1000),
+        _hud(40, fl=1000, fr=1000, el=1000, er=700),
+    ]
+    assert _training_target(_interaction(window)) == 300.0
+
+
+def test_mixed_damage_combines_per_spec_formula() -> None:
+    # friendly_left -200, friendly_right -100, enemy_left -50, enemy_right -300
+    # → (-200 + -100) - (-50 + -300) = +50
+    window = [
+        _hud(0, fl=1000, fr=1000, el=1000, er=1000),
+        _hud(40, fl=800, fr=900, el=950, er=700),
+    ]
+    assert _training_target(_interaction(window)) == 50.0
+
+
+def test_unreadable_end_tower_signals_drop() -> None:
+    window = [
+        _hud(0, fl=1000, fr=1000, el=1000, er=1000),
+        _hud(40, fl=None, fr=900, el=950, er=700),
+    ]
+    assert _training_target(_interaction(window)) is None
+
+
+def test_unreadable_start_tower_signals_drop() -> None:
+    window = [
+        _hud(0, fl=1000, fr=None, el=1000, er=1000),
+        _hud(40, fl=800, fr=900, el=950, er=700),
+    ]
+    assert _training_target(_interaction(window)) is None
+
+
+def test_no_damage_yields_zero_target() -> None:
+    window = [
+        _hud(0, fl=1000, fr=1000, el=1000, er=1000),
+        _hud(40, fl=1000, fr=1000, el=1000, er=1000),
+    ]
+    assert _training_target(_interaction(window)) == 0.0

--- a/uv.lock
+++ b/uv.lock
@@ -480,6 +480,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "pytesseract" },
+    { name = "scikit-learn" },
     { name = "scipy" },
     { name = "seaborn" },
     { name = "statsmodels" },
@@ -508,6 +509,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.2" },
     { name = "pyarrow", specifier = ">=17" },
     { name = "pytesseract", specifier = ">=0.3.13" },
+    { name = "scikit-learn", specifier = ">=1.5" },
     { name = "scipy", specifier = ">=1.14" },
     { name = "seaborn", specifier = ">=0.13.2" },
     { name = "statsmodels", specifier = ">=0.14" },
@@ -2661,6 +2663,56 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/92/53ea2181da8ac6bf27170191028aee7251f8f841f8d3edbfdcaf2008fde9/scikit_learn-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:146b4d36f800c013d267b29168813f7a03a43ecd2895d04861f1240b564421da", size = 8595835, upload-time = "2025-12-10T07:07:39.385Z" },
+    { url = "https://files.pythonhosted.org/packages/01/18/d154dc1638803adf987910cdd07097d9c526663a55666a97c124d09fb96a/scikit_learn-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f984ca4b14914e6b4094c5d52a32ea16b49832c03bd17a110f004db3c223e8e1", size = 8080381, upload-time = "2025-12-10T07:07:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/44/226142fcb7b7101e64fdee5f49dbe6288d4c7af8abf593237b70fca080a4/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e30adb87f0cc81c7690a84f7932dd66be5bac57cfe16b91cb9151683a4a2d3b", size = 8799632, upload-time = "2025-12-10T07:07:43.899Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4d/4a67f30778a45d542bbea5db2dbfa1e9e100bf9ba64aefe34215ba9f11f6/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ada8121bcb4dac28d930febc791a69f7cb1673c8495e5eee274190b73a4559c1", size = 9103788, upload-time = "2025-12-10T07:07:45.982Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3c/45c352094cfa60050bcbb967b1faf246b22e93cb459f2f907b600f2ceda5/scikit_learn-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:c57b1b610bd1f40ba43970e11ce62821c2e6569e4d74023db19c6b26f246cb3b", size = 8081706, upload-time = "2025-12-10T07:07:48.111Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/46/5416595bb395757f754feb20c3d776553a386b661658fb21b7c814e89efe/scikit_learn-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:2838551e011a64e3053ad7618dda9310175f7515f1742fa2d756f7c874c05961", size = 7688451, upload-time = "2025-12-10T07:07:49.873Z" },
+    { url = "https://files.pythonhosted.org/packages/90/74/e6a7cc4b820e95cc38cf36cd74d5aa2b42e8ffc2d21fe5a9a9c45c1c7630/scikit_learn-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fb63362b5a7ddab88e52b6dbb47dac3fd7dafeee740dc6c8d8a446ddedade8e", size = 8548242, upload-time = "2025-12-10T07:07:51.568Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d8/9be608c6024d021041c7f0b3928d4749a706f4e2c3832bbede4fb4f58c95/scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5025ce924beccb28298246e589c691fe1b8c1c96507e6d27d12c5fadd85bfd76", size = 8079075, upload-time = "2025-12-10T07:07:53.697Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/47/f187b4636ff80cc63f21cd40b7b2d177134acaa10f6bb73746130ee8c2e5/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4496bb2cf7a43ce1a2d7524a79e40bc5da45cf598dbf9545b7e8316ccba47bb4", size = 8660492, upload-time = "2025-12-10T07:07:55.574Z" },
+    { url = "https://files.pythonhosted.org/packages/97/74/b7a304feb2b49df9fafa9382d4d09061a96ee9a9449a7cbea7988dda0828/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bcfe4d0d14aec44921545fd2af2338c7471de9cb701f1da4c9d85906ab847a", size = 8931904, upload-time = "2025-12-10T07:07:57.666Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c4/0ab22726a04ede56f689476b760f98f8f46607caecff993017ac1b64aa5d/scikit_learn-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:35c007dedb2ffe38fe3ee7d201ebac4a2deccd2408e8621d53067733e3c74809", size = 8019359, upload-time = "2025-12-10T07:07:59.838Z" },
+    { url = "https://files.pythonhosted.org/packages/24/90/344a67811cfd561d7335c1b96ca21455e7e472d281c3c279c4d3f2300236/scikit_learn-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:8c497fff237d7b4e07e9ef1a640887fa4fb765647f86fbe00f969ff6280ce2bb", size = 7641898, upload-time = "2025-12-10T07:08:01.36Z" },
+    { url = "https://files.pythonhosted.org/packages/03/aa/e22e0768512ce9255eba34775be2e85c2048da73da1193e841707f8f039c/scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a", size = 8513770, upload-time = "2025-12-10T07:08:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/58/37/31b83b2594105f61a381fc74ca19e8780ee923be2d496fcd8d2e1147bd99/scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e", size = 8044458, upload-time = "2025-12-10T07:08:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5a/3f1caed8765f33eabb723596666da4ebbf43d11e96550fb18bdec42b467b/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57", size = 8610341, upload-time = "2025-12-10T07:08:07.732Z" },
+    { url = "https://files.pythonhosted.org/packages/38/cf/06896db3f71c75902a8e9943b444a56e727418f6b4b4a90c98c934f51ed4/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e", size = 8900022, upload-time = "2025-12-10T07:08:09.862Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f9/9b7563caf3ec8873e17a31401858efab6b39a882daf6c1bfa88879c0aa11/scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271", size = 7989409, upload-time = "2025-12-10T07:08:12.028Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/1f4001503650e72c4f6009ac0c4413cb17d2d601cef6f71c0453da2732fc/scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3", size = 7619760, upload-time = "2025-12-10T07:08:13.688Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/7d/a630359fc9dcc95496588c8d8e3245cc8fd81980251079bc09c70d41d951/scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735", size = 8826045, upload-time = "2025-12-10T07:08:15.215Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/56/a0c86f6930cfcd1c7054a2bc417e26960bb88d32444fe7f71d5c2cfae891/scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd", size = 8420324, upload-time = "2025-12-10T07:08:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/46/1e/05962ea1cebc1cf3876667ecb14c283ef755bf409993c5946ade3b77e303/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e", size = 8680651, upload-time = "2025-12-10T07:08:19.952Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/56/a85473cd75f200c9759e3a5f0bcab2d116c92a8a02ee08ccd73b870f8bb4/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb", size = 8925045, upload-time = "2025-12-10T07:08:22.11Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b7/64d8cfa896c64435ae57f4917a548d7ac7a44762ff9802f75a79b77cb633/scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702", size = 8507994, upload-time = "2025-12-10T07:08:23.943Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/37/e192ea709551799379958b4c4771ec507347027bb7c942662c7fbeba31cb/scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde", size = 7869518, upload-time = "2025-12-10T07:08:25.71Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667, upload-time = "2025-12-10T07:08:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524, upload-time = "2025-12-10T07:08:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133, upload-time = "2025-12-10T07:08:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223, upload-time = "2025-12-10T07:08:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518, upload-time = "2025-12-10T07:08:36.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546, upload-time = "2025-12-10T07:08:38.128Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305, upload-time = "2025-12-10T07:08:41.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257, upload-time = "2025-12-10T07:08:42.873Z" },
+    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673, upload-time = "2025-12-10T07:08:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467, upload-time = "2025-12-10T07:08:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395, upload-time = "2025-12-10T07:08:49.337Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647, upload-time = "2025-12-10T07:08:51.601Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2856,6 +2908,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Wave 2 of [Finish Clash Royale Post-Game Analyzer](SPEC.md) — replace the `elixir_trade` proxy EV target with a tower-HP-delta target. Structural deliverable: contracts locked, training pipeline rewired, holdout protocol coded, per-card stats round-trip. Real metrics blocked by an HF-loader gap surfaced during validation; queued as a wave-2C follow-up.

## Chunks in this wave

- `swarm/finish-project-wave-2-scaffold` (commits `3da1154`, `d8f3021`) — Locked contracts: flat `HudState.{friendly,enemy}_{left,right}_princess_hp: int|None`, `tower_hp_delta(window) → dict[str, int|None]` keyed `{friendly,enemy}_{left,right}`, `Interaction.tower_hp_delta`. `HudReader.read` now populates the four princess fields; `build_interactions` accepts an optional `hud` list and bookend-deltas each window.
- `swarm/finish-project-wave-2a-ev-label` — Replaced `interaction.elixir_trade` with `(friendly_left + friendly_right) - (enemy_left + enemy_right)` deltas in `_cmd_train`. Drops rows whose HUD bookends are unreadable and logs the drop rate. Pure-Python tests in `tests/test_ev_target.py` cover the four spec cases plus unreadable-start/end and zero-damage.
- `swarm/finish-project-wave-2b-retrain-validate` — Per-card `(median, std)` table computed from the **training fold** (anchor friendly play; cards <5 samples excluded), persisted inside the `EvModel` artifact for wave 3 to consume. 80/20 replay-level holdout with deterministic shuffle. MAE + Spearman printed in `_cmd_train`. Round-trip test in `tests/test_ev_model.py`. `scikit-learn` added as an explicit dep (lightgbm sklearn API) plus a pandas 3.0 StringDtype fix.

## Known gap — wave 2C will close it

`docs/ev-validation.md` documents that an end-to-end Brev A6000 run dropped `768/768` rows (100%) because `HFReplayLoader._parquet_to_replay` returns `Replay(hud=[])`. Wave-2A's synthetic-only tests didn't catch this. A wave-2C chunk will wire `HudReader` into the HF loader so real metrics can land. Wave 3 (blunders) is unblocked: it depends on `per_card_stats` *shape*, not on the model being trained yet.

## Verification

1. `crpod train ...` runs end-to-end and exits cleanly. Real metrics blocked on wave 2C — see `docs/ev-validation.md`. — _wave 2C_
2. `crpod analyze-video ...` (`blunders.json`, `report.html`). — _waves 3-4_
3. `docs/latency-budget.md`. — _wave 4_
4. `scripts/smoke_arena15.sh`. — _wave 4_
5. `make lint format type-check test` — 61/61 tests pass on this branch.
6. README + TODO polish. — _wave 4_

---
_Generated by `/swarm`. Spec: `SPEC.md`._