### PR TITLE
Wave 2C: wire HudReader into HF replay loader

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -160,4 +160,4 @@ _Wave 1 executed 2026-05-01 on branch swarm/finish-project-wave-1; chunks 1a-sid
 
 _Wave 2 executed 2026-05-01 on branch swarm/finish-project-wave-2; chunks 2a-ev-label, 2b-retrain-validate; PR https://github.com/max-miller1204/Clash-Royale-Pod/pull/26_
 
-_Wave 2C executed 2026-05-01 on branch swarm/finish-project-wave-2c-hud-on-hf; chunks 2c-hud-on-hf (structural fix only — `Replay.hud` now populated from HF parquet); PR pending. Real `docs/ev-validation.md` metrics deferred to wave 2D (brev retrain run)._
+_Wave 2C executed 2026-05-01 on branch swarm/finish-project-wave-2c-hud-on-hf; chunks 2c-hud-on-hf (structural fix only — `Replay.hud` now populated from HF parquet); PR https://github.com/max-miller1204/Clash-Royale-Pod/pull/27 (stacked on #26). Real `docs/ev-validation.md` metrics deferred to wave 2D (brev retrain run)._

--- a/SPEC.md
+++ b/SPEC.md
@@ -159,3 +159,5 @@ Upstream remote: origin
 _Wave 1 executed 2026-05-01 on branch swarm/finish-project-wave-1; chunks 1a-side-inference, 1b-champion-costs, 1c-yolo-pod-audit; PR https://github.com/max-miller1204/Clash-Royale-Pod/pull/24_
 
 _Wave 2 executed 2026-05-01 on branch swarm/finish-project-wave-2; chunks 2a-ev-label, 2b-retrain-validate; PR https://github.com/max-miller1204/Clash-Royale-Pod/pull/26_
+
+_Wave 2C executed 2026-05-01 on branch swarm/finish-project-wave-2c-hud-on-hf; chunks 2c-hud-on-hf (structural fix only — `Replay.hud` now populated from HF parquet); PR pending. Real `docs/ev-validation.md` metrics deferred to wave 2D (brev retrain run)._

--- a/src/crpod/dataset/huggingface.py
+++ b/src/crpod/dataset/huggingface.py
@@ -125,9 +125,7 @@ def _parquet_to_replay(path: Path, arena: str, replay_id: str, detector: YoloDet
             hud_states.append(hud_reader.read(frame_id, bgr))
         except Exception:
             ocr_failures += 1
-            hud_states.append(
-                HudState(frame=frame_id, friendly_elixir=0.0, enemy_elixir=None)
-            )
+            hud_states.append(HudState(frame=frame_id, friendly_elixir=0.0, enemy_elixir=None))
         now = time.monotonic()
         if processed % progress_every == 0 or now - last_log_wall >= 15.0:
             ocr_pct = int(round(100 * ocr_failures / processed))

--- a/src/crpod/dataset/huggingface.py
+++ b/src/crpod/dataset/huggingface.py
@@ -16,6 +16,8 @@ if you find it.
 
 from __future__ import annotations
 
+import sys
+import time
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -24,8 +26,9 @@ import numpy as np
 
 from crpod.detection.cards import to_card_play
 from crpod.detection.yolo import YoloDetector
+from crpod.ocr.hud import HudReader
 from crpod.tracking.bytetrack import Tracker
-from crpod.types import CardPlay, Replay
+from crpod.types import CardPlay, HudState, Replay
 
 DATASET_ID = "chrisrca/clash-royale-tv-replays"
 
@@ -106,7 +109,35 @@ def _decode_frames(path: Path) -> Iterator[tuple[int, np.ndarray]]:
 
 
 def _parquet_to_replay(path: Path, arena: str, replay_id: str, detector: YoloDetector) -> Replay:
-    detections = list(detector.infer(_decode_frames(path)))
+    # Materialize frames once so we can feed the same decoded BGR ndarrays
+    # to both YOLO detection and HUD OCR. HF replays are short — fits in RAM.
+    frames: list[tuple[int, np.ndarray]] = list(_decode_frames(path))
+    detections = list(detector.infer(frames))
+
+    hud_reader = HudReader()
+    hud_states: list[HudState] = []
+    total_decoded = len(frames)
+    progress_every = max(1, total_decoded // 20)  # ~5%
+    last_log_wall = time.monotonic()
+    ocr_failures = 0
+    for processed, (frame_id, bgr) in enumerate(frames, start=1):
+        try:
+            hud_states.append(hud_reader.read(frame_id, bgr))
+        except Exception:
+            ocr_failures += 1
+            hud_states.append(
+                HudState(frame=frame_id, friendly_elixir=0.0, enemy_elixir=None)
+            )
+        now = time.monotonic()
+        if processed % progress_every == 0 or now - last_log_wall >= 15.0:
+            ocr_pct = int(round(100 * ocr_failures / processed))
+            print(
+                f"[crpod-hf] {replay_id} hud={processed}/{total_decoded} ocr_fail={ocr_pct}%",
+                file=sys.stderr,
+                flush=True,
+            )
+            last_log_wall = now
+
     tracker = Tracker(frame_rate=10)
     tracks = tracker.update(detections)
     plays: list[CardPlay] = []
@@ -124,7 +155,7 @@ def _parquet_to_replay(path: Path, arena: str, replay_id: str, detector: YoloDet
         replay_id=replay_id,
         arena=arena,
         plays=plays,
-        hud=[],
+        hud=hud_states,
         total_frames=total_frames,
         fps=10.0,
     )

--- a/tests/test_hf_replay.py
+++ b/tests/test_hf_replay.py
@@ -4,10 +4,12 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import cast
 
+import numpy as np
 import pytest
 
 from crpod.dataset import huggingface as hf
 from crpod.detection.yolo import Detection, YoloDetector
+from crpod.types import HudState
 
 
 def _det(frame: int, cls: str, x: float, y: float) -> Detection:
@@ -93,3 +95,91 @@ def test_parquet_to_replay_preserves_katacr_mapping(silenced_decode: None) -> No
         f"expected exactly 1 'log' CardPlay (KATACR mapping + tracker collapse), "
         f"got {len(log_plays)}: {[p.card for p in replay.plays]}"
     )
+
+
+class _StubHudReader:
+    """Records every call and returns a canned `HudState` with princess-HP fields populated.
+
+    Lets the unit test assert that `_parquet_to_replay` runs HUD OCR over the
+    same decoded frames it feeds to YOLO, without spinning up tesseract.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[int] = []
+
+    def read(self, frame_idx: int, frame: np.ndarray) -> HudState:
+        self.calls.append(frame_idx)
+        return HudState(
+            frame=frame_idx,
+            friendly_elixir=5.0,
+            enemy_elixir=4.0,
+            friendly_left_princess_hp=2800,
+            friendly_right_princess_hp=2800,
+            enemy_left_princess_hp=2700,
+            enemy_right_princess_hp=2700,
+        )
+
+
+def test_parquet_to_replay_populates_hud(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_parquet_to_replay` must run `HudReader.read` per decoded frame and
+    populate `Replay.hud`. Regression for the wave-2A scoping miss where the
+    HF loader returned `Replay(..., hud=[])` and dropped 100% of training rows.
+    """
+    fake_frames = [
+        (i, np.zeros((960, 540, 3), dtype=np.uint8)) for i in range(4)
+    ]
+    monkeypatch.setattr(hf, "_decode_frames", lambda path: iter(fake_frames))
+    stub_reader = _StubHudReader()
+    monkeypatch.setattr(hf, "HudReader", lambda: stub_reader)
+
+    detector = _StubDetector([_det(i, "knight", x=200, y=400) for i in range(4)])
+
+    replay = hf._parquet_to_replay(
+        Path("ignored.parquet"),
+        arena="arena_15",
+        replay_id="r1",
+        detector=cast(YoloDetector, detector),
+    )
+
+    assert len(replay.hud) == len(fake_frames), (
+        f"expected one HudState per decoded frame, got {len(replay.hud)}"
+    )
+    assert stub_reader.calls == [0, 1, 2, 3], (
+        f"HudReader.read called with unexpected frame ids: {stub_reader.calls}"
+    )
+    first = replay.hud[0]
+    assert first.friendly_left_princess_hp == 2800
+    assert first.enemy_left_princess_hp == 2700
+
+
+def test_parquet_to_replay_swallows_hud_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A single bad HUD frame must not kill the whole replay — mirror the
+    OCR-failure swallow already in `analyze_video`. The unreadable frame
+    falls back to a `HudState` with `enemy_elixir=None` so wave-2A's
+    drop-on-None policy applies per-interaction, not per-replay.
+    """
+    fake_frames = [
+        (i, np.zeros((960, 540, 3), dtype=np.uint8)) for i in range(3)
+    ]
+    monkeypatch.setattr(hf, "_decode_frames", lambda path: iter(fake_frames))
+
+    class _FlakyReader:
+        def read(self, frame_idx: int, frame: np.ndarray) -> HudState:
+            if frame_idx == 1:
+                raise RuntimeError("tesseract exploded")
+            return HudState(frame=frame_idx, friendly_elixir=3.0, enemy_elixir=2.0)
+
+    monkeypatch.setattr(hf, "HudReader", _FlakyReader)
+    detector = _StubDetector([])
+
+    replay = hf._parquet_to_replay(
+        Path("ignored.parquet"),
+        arena="arena_15",
+        replay_id="r1",
+        detector=cast(YoloDetector, detector),
+    )
+
+    assert len(replay.hud) == 3
+    assert replay.hud[1].enemy_elixir is None, "fallback HudState should signal unreadable"
+    assert replay.hud[0].enemy_elixir == 2.0
+    assert replay.hud[2].enemy_elixir == 2.0

--- a/tests/test_hf_replay.py
+++ b/tests/test_hf_replay.py
@@ -125,9 +125,7 @@ def test_parquet_to_replay_populates_hud(monkeypatch: pytest.MonkeyPatch) -> Non
     populate `Replay.hud`. Regression for the wave-2A scoping miss where the
     HF loader returned `Replay(..., hud=[])` and dropped 100% of training rows.
     """
-    fake_frames = [
-        (i, np.zeros((960, 540, 3), dtype=np.uint8)) for i in range(4)
-    ]
+    fake_frames = [(i, np.zeros((960, 540, 3), dtype=np.uint8)) for i in range(4)]
     monkeypatch.setattr(hf, "_decode_frames", lambda path: iter(fake_frames))
     stub_reader = _StubHudReader()
     monkeypatch.setattr(hf, "HudReader", lambda: stub_reader)
@@ -158,9 +156,7 @@ def test_parquet_to_replay_swallows_hud_failures(monkeypatch: pytest.MonkeyPatch
     falls back to a `HudState` with `enemy_elixir=None` so wave-2A's
     drop-on-None policy applies per-interaction, not per-replay.
     """
-    fake_frames = [
-        (i, np.zeros((960, 540, 3), dtype=np.uint8)) for i in range(3)
-    ]
+    fake_frames = [(i, np.zeros((960, 540, 3), dtype=np.uint8)) for i in range(3)]
     monkeypatch.setattr(hf, "_decode_frames", lambda path: iter(fake_frames))
 
     class _FlakyReader:


### PR DESCRIPTION
Stacked on PR #26 (wave 2). Closes the gap that wave 2's Brev retrain surfaced: `HFReplayLoader._parquet_to_replay` returned `Replay(hud=[])`, so wave 2A's tower-HP-delta target dropped 100% of training rows. With `Replay.hud` populated, `Interaction.tower_hp_delta` carries real values and `_cmd_train` actually has rows to train on.

## Changes

- `src/crpod/dataset/huggingface.py` — materialize `_decode_frames(path)` into a list once, run YOLO over it (existing), then run `HudReader.read` over the same frames in a parallel loop. Mirror `analyze_video`'s OCR-failure swallow so a single bad frame doesn't kill the replay. `Replay.hud` now has one `HudState` per decoded frame.
- `tests/test_hf_replay.py` — two new tests: `test_parquet_to_replay_populates_hud` (stubs YOLO + HudReader, asserts `Replay.hud` non-empty), `test_parquet_to_replay_swallows_hud_failures` (HudReader raises → fallback HudState lands).
- `style: ruff format wave-2c additions` — minor formatter tidy on the new code.

63/63 tests pass under `nix develop -c bash -c 'uv run ruff format --check . && uv run ruff check . && uv run mypy src && uv run pytest -q'`.

## Known follow-up — wave 2D

Wave 2D will run `crpod train` end-to-end on Brev to fill in real `(MAE, Spearman)` numbers in `docs/ev-validation.md`. This PR is structural only — the agent did not have Brev access in the worktree and (per CHUNK.md ground rule) surfaced the blocker rather than faking metrics. Wave 3 (blunders) is unblocked: `EvModel.per_card_stats` round-trip is already proven by `tests/test_ev_model.py`.

---
_Generated by `/swarm`. Spec: `SPEC.md`._