### PR TITLE
docs(CLAUDE.md): add wave/swarm PR-targeting rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,3 @@
 1. Use nix shells for running commands
-2. My computer has very low compute power. Use brev for anything with intensive CPU or GPU activity. 
+2. My computer has very low compute power. Use brev for anything with intensive CPU or GPU activity.
+3. Wave/swarm PRs target `main` directly unless the wave depends on unmerged work in another branch. If a `swarm/*` branch absorbs another wave's PR (stacked PRs), open the trailing `swarm/* → main` PR in the same step — never leave a `swarm/*` branch ahead of `main` after a wave is "done". Before declaring a wave complete, verify its commits are reachable from `origin/main`, not just from a `swarm/*` branch. 


### PR DESCRIPTION
## Summary
Cherry-picks the CLAUDE.md rule that was bundled on `swarm/wave-2h-top-ladder-data` so it lands on `main` independently of wave 2H.

Adds rule #3 to `CLAUDE.md`:

> Wave/swarm PRs target `main` directly unless the wave depends on unmerged work in another branch. If a `swarm/*` branch absorbs another wave's PR (stacked PRs), open the trailing `swarm/* → main` PR in the same step — never leave a `swarm/*` branch ahead of `main` after a wave is "done". Before declaring a wave complete, verify its commits are reachable from `origin/main`, not just from a `swarm/*` branch.

Locks in the lesson from wave 2F (PR #31 merged into a `swarm/*` integration branch and sat off-main for ~24h until PR #33 caught it).

## Test plan
- [x] No code change — docs only