### PR TITLE
docs(spec): set Dispatch: tmux explicitly in Execution

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -184,6 +184,7 @@ Base strategy: upstream-trunk
 Branch naming: swarm/{slug}-wave-{n}
 Fork remote: origin
 Upstream remote: origin
+Dispatch: tmux
 
 _Wave 1 executed 2026-05-01 on branch swarm/finish-project-wave-1; chunks 1a-side-inference, 1b-champion-costs, 1c-yolo-pod-audit; PR https://github.com/max-miller1204/Clash-Royale-Pod/pull/24_
 


### PR DESCRIPTION
## Summary
- The `/swarm` skill recently added a `Dispatch:` field to the parsed `## Execution` section, with two valid values:
  - `Dispatch: tmux` (default; current behavior — spawn Claude CLI sessions in tmux panes via `tslw`/`tslwm`)
  - `Dispatch: agents` (experimental; uses Claude Code's Agent fork feature with `isolation: \"worktree\"` — see [`agents-dispatch.md`](https://github.com/max/dotfiles))
- Absent → defaults to `tmux` silently, so this PR is purely documenting current intent.
- Single-line addition to `## Execution`. No impact on in-flight wave 2J' work or any other branch.

## Test plan
- [x] One-line edit; `git diff` shows only the new `Dispatch: tmux` line under `Upstream remote: origin`
- [x] Independent of branch \`swarm/wave-2j-prime-feature-add\` (still in flight) — no merge conflict expected