### PR TITLE
docs: polish TODO + README artifact links (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,11 @@ After pulling the latest changes from main, check what files changed and follow 
 - **[docs/ev-validation.md](./docs/ev-validation.md)** — Per-wave EV model holdout metrics (Spearman ρ trajectory)
 - **[docs/latency-budget.md](./docs/latency-budget.md)** — Per-stage CPU latency baseline
 - **[docs/known-issues.md](./docs/known-issues.md)** — Carried limitations and deferred work
-- **[docs/artifacts/](./docs/artifacts/)** — Standalone HTML explainers: project overview, blunder math, final state
+- **Standalone HTML explainers** (in [`docs/artifacts/`](./docs/artifacts/)):
+  - **[Project overview](./docs/artifacts/00-overview.html)** — pipeline architecture and research question
+  - **[How blunder detection works](./docs/artifacts/01-blunder-detection.html)** — the per-card median + σ threshold
+  - **[The post-game report — design notes](./docs/artifacts/02-html-report.html)** — what's in `report.html` and why
+  - **[Project final state](./docs/artifacts/03-final-state.html)** — what shipped vs. what was deferred
 
 ## Tech Stack
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -50,7 +50,7 @@ The offline architecture already supports this — the CV stages run ~30-50ms/fr
 - [ ] **Live side labeling.** The HF-dataset `_infer_side` y-split won't work live — you're viewing your own POV, both sides visible. Key off UI elements instead: your deck sits at the bottom of the frame, opponent's at the top. Detect card thumbnails in the hand strip to disambiguate who played what.
 - [ ] **Rolling EV inference.** Wire the trained `EvModel` into the stream loop — on each completed interaction, run `predict` and emit a live signal (stdout, WebSocket, or overlay). LightGBM single-row inference is ~1ms, well under budget.
 - [ ] **`crpod live` CLI subcommand.** Wraps the stream pipeline: `crpod live --source 0 --model output/models/ev.joblib`. Prints rolling tempo, per-interaction EV, and blunder flags in real time.
-- [ ] **Latency budget audit.** Profile the full pipeline on target hardware. KataCR hit ~120ms/decision + 240ms feature fusion on an RTX 4060 — be skeptical of "<100ms" claims until measured. Record p50/p95/p99 per stage.
+- [x] **Latency budget audit.** Shipped in PR #42: `scripts/latency_audit.py` + `scripts/latency_report.py` produce per-stage p50/p95/p99 and the baseline numbers landed in `docs/latency-budget.md`.
 - [ ] **Overlay renderer (stretch).** OBS browser source or an always-on-top window showing live tempo graph + EV readouts. Only after the core pipeline is solid.
 
 **Caveat:** `pod_summary.md` scopes the project as offline post-game analysis. Real-time is a genuine expansion — viable with this codebase as the foundation, but it pushes the deliverable past the 10-week timeline unless some offline features get dropped. Recommend shipping offline first (weeks 1-6), training YOLO in parallel (weeks 2-5), then building `crpod live` in weeks 7-9.
@@ -62,7 +62,7 @@ The offline architecture already supports this — the CV stages run ~30-50ms/fr
 - [x] **Latency-budget audit.** Wave 4B added `crpod.instrumentation.Timer` + `scripts/latency_audit.py` + `scripts/latency_report.py`. Baseline measurements landed in `docs/latency-budget.md` (CPU floor across 3× 30 s clips, YOLO dominates).
 - [x] **arena_15 smoke harness.** Wave 4C added `scripts/smoke_arena15.sh` that walks all 76 replays end-to-end. 8/8 sample run on CPU passes; full-pool run is brev-friendly. Remaining edge cases tracked in `docs/known-issues.md`.
 - [x] **GitHub Actions CI.** `.github/workflows/ci.yml` runs `ruff check`, `ruff format --check`, `mypy src`, and `pytest` on PRs to `main` via `cachix/install-nix-action` + `nix develop --command`, so CI matches the local flake. All four checks pass locally on this branch.
-- [ ] **Wave 2K — model class A/B + hyperparameter sweep.** Branch `swarm/wave-2k-model-class-ab` is scaffolded with the CV-sweep script. Awaiting a brev run (cost ≈ $10 / 14 h on A6000+). The next signal-quality lift if `+0.223` ρ isn't enough.
+- [ ] **Wave 2K — model class A/B + hyperparameter sweep.** Scaffolded on `origin/swarm/wave-2k-model-class-ab` with the CV-sweep script; tracked by issue #43. Awaiting a brev run (cost ≈ $10 / 14 h on A6000+). The next signal-quality lift if `+0.223` ρ isn't enough.
 
 ## Suggested order
 


### PR DESCRIPTION
## Summary

Closes #61. Three small doc-only fixes from the post-finish audit, bundled as the umbrella issue requested.

- **`docs/TODO.md:53`** — flipped the real-time "Latency budget audit" item to `[x]` and pointed at PR #42's artifacts (`scripts/latency_audit.py`, `scripts/latency_report.py`, `docs/latency-budget.md`).
- **`docs/TODO.md:65`** — replaced the dangling local-branch reference (`swarm/wave-2k-model-class-ab` was deleted locally) with `origin/swarm/wave-2k-model-class-ab` and a pointer to tracking issue #43.
- **`README.md`** — expanded the `docs/artifacts/` bullet in *Key Docs* into individual links for all four HTML explainers (overview, blunder detection, post-game report design notes, final state) so they're actually discoverable from the README.

## Test plan

- [x] `git diff` shows ~7 lines changed across 2 files, no functional code touched
- [x] All four `docs/artifacts/*.html` files exist at the linked paths
- [x] Closes #61